### PR TITLE
Endpoints objects match

### DIFF
--- a/src/canvas/Document.tsx
+++ b/src/canvas/Document.tsx
@@ -100,7 +100,7 @@ export class Document implements IDocument {
                     continue;
                 }
 
-                if (point.equals(o.point)) {
+                if (point === o.point) {
                     endpoints[i].matched = true;
                     endpoints[j].matched = true;
                 }

--- a/src/canvas/Geometry/ArcCurve.tsx
+++ b/src/canvas/Geometry/ArcCurve.tsx
@@ -115,7 +115,8 @@ export class ArcCurve extends Curve {
     };
 
     // Overrides the abstract method in the parent class.
-    protected computePoint = (t: number): Point => {     
+    // Precondition: t is a number between 0 and 1, excluding 0 and 1.
+    protected _computePoint = (t: number): Point => {     
         const x = this.center.x + 
                   this.radius * Math.cos(this.lerp(this.startAngle, this.endAngle, t));
         const y = this.center.y + 

--- a/src/canvas/Geometry/BezierCurve.tsx
+++ b/src/canvas/Geometry/BezierCurve.tsx
@@ -48,8 +48,8 @@ export class BezierCurve extends Curve {
     // its end point. If t=0, it returns the starting point. If t=1, 
     // it returns the end point.
     // Overrides abstract method in parent
-    // Precondition: t is a number between 0 and 1
-    protected computePoint = (t: number): Point => {
+    // Precondition: t is a number between 0 and 1, excluding 0 and 1
+    protected _computePoint = (t: number): Point => {
         // Using De Casteljau's algorithm instead of the parametric equation.
         // This method is slower but more stable.
         const startToControlX = this.lerp(this.start.x, this.control.x, t);

--- a/src/canvas/Geometry/Curve.tsx
+++ b/src/canvas/Geometry/Curve.tsx
@@ -10,7 +10,18 @@ export abstract class Curve extends Segment {
         this.control = control;
     }
 
-    protected abstract computePoint(t: number): Point;
+    protected computePoint = (t: number): Point => {
+        // If t is 0 or 1, return the start or end points respectively.
+        if (t === 0) {
+            return this.start;
+        } else if (t === 1) {
+            return this.end;
+        }
+
+        return this._computePoint(t);
+    };
+
+    protected abstract _computePoint(t: number): Point;
 
     computePoints = (numPoints?: number): Point[] => {
         numPoints = numPoints || 100;

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -11,11 +11,8 @@ export class PatternPath implements IPatternPath {
     constructor (pathType: PatternPathType, segment: Segment) {
         this._type = pathType;
         this._segment = segment;
-
         this._points = segment.computePoints();
-
-        this._path2D = new Path2D();
-        this._updatePath2D();
+        this._path2D = this._computePath2D();
     }
 
     getPoints = (): Point[] => {
@@ -65,10 +62,11 @@ export class PatternPath implements IPatternPath {
         return paths;
     };   
     
-    protected _updatePath2D = (): void => {
-        this._path2D = new Path2D();
-        const start = this._segment.getStart();
-        this._path2D.moveTo(start.x, start.y);
-        this._segment.drawTo(this._path2D);
+    protected _computePath2D = (): Path2D => {
+        const result = new Path2D();
+        const start = this.getStartPoint();
+        result.moveTo(start.x, start.y);
+        this._segment.drawTo(result);
+        return result;
     };
 }

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -12,7 +12,8 @@ export class PatternPath implements IPatternPath {
         this._type = pathType;
         this._segment = segment;
         this._points = segment.computePoints();
-        this._path2D = this._computePath2D();
+        this._path2D = new Path2D();
+        this._updatePath2D();
     }
 
     getPoints = (): Point[] => {
@@ -62,11 +63,10 @@ export class PatternPath implements IPatternPath {
         return paths;
     };   
     
-    protected _computePath2D = (): Path2D => {
-        const result = new Path2D();
+    protected _updatePath2D = (): void => {
+        this._path2D = new Path2D();
         const start = this.getStartPoint();
-        result.moveTo(start.x, start.y);
-        this._segment.drawTo(result);
-        return result;
+        this._path2D.moveTo(start.x, start.y);
+        this._segment.drawTo(this._path2D);
     };
 }

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -20,14 +20,6 @@ export class PatternPath implements IPatternPath {
         return this._points;
     };
 
-    getStartPoint = (): Point => {
-        return this._points[0];
-    };
-
-    getEndPoint = (): Point => {
-        return this._points[this._points.length - 1];
-    };
-
     getType = (): PatternPathType => {
         return this._type;
     };

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -13,12 +13,6 @@ export class PatternPath implements IPatternPath {
         this._segment = segment;
 
         this._points = segment.computePoints();
-        if (!this._points[0].equals(segment.getStart())) {
-            this._points.unshift(segment.getStart());
-        }
-        if (!this._points[this._points.length - 1].equals(segment.getEnd())) {
-            this._points.push(segment.getEnd());
-        }
 
         this._path2D = new Path2D();
         this._updatePath2D();

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -22,6 +22,14 @@ export class PatternPath implements IPatternPath {
         return this._points;
     };
 
+    getStartPoint = (): Point => {
+        return this._points[0];
+    };
+
+    getEndPoint = (): Point => {
+        return this._points[this._points.length - 1];
+    };
+
     getType = (): PatternPathType => {
         return this._type;
     };

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -57,7 +57,7 @@ export class PatternPath implements IPatternPath {
     
     protected _updatePath2D = (): void => {
         this._path2D = new Path2D();
-        const start = this.getStartPoint();
+        const start = this._points[0];
         this._path2D.moveTo(start.x, start.y);
         this._segment.drawTo(this._path2D);
     };

--- a/src/canvas/Renderer.tsx
+++ b/src/canvas/Renderer.tsx
@@ -246,14 +246,16 @@ export class Renderer implements IRenderer {
                 this._currPath.addPoint(callback());
             }
 
+            let newPatternPath;
             const points = this._currPath.getPoints();
             switch (this._toolType) {
                 case ToolType.StraightLine:
-                    this._document.addPatternPath(new PatternPath(this._pathType, new LineSegment(points[0], points[1])));
+                    newPatternPath = new PatternPath(this._pathType, new LineSegment(points[0], points[1]));
                     break;
                 case ToolType.Freeline:
-                    this._document.addPatternPath(new PatternPath(this._pathType, CurveFitter.Fit(points)));
+                    newPatternPath = new PatternPath(this._pathType, CurveFitter.Fit(points));
             }
+            this._document.addPatternPath(newPatternPath);
 
             console.log("paths", this._document.getPatternPaths());
             this._canvas.dispatchEvent(new Event('endTracing'));     

--- a/src/canvas/Renderer.tsx
+++ b/src/canvas/Renderer.tsx
@@ -261,10 +261,17 @@ export class Renderer implements IRenderer {
         this._resetTracing();
     };
 
+    /**
+     * Splits the path crossed by the intersection in 2 at the point
+     * that is closest to the intersection's point on the path. 
+     * Updates the patternPath list in the document, and returns
+     * the new endpoint shared by the 2 pieces of the split paths
+     * @param intersection 
+     */
     private _handleIntersection = (intersection: IIntersection): Point => {
         const splitPaths: PatternPath[] = intersection.pathCrossed.splitAtPoint(intersection.point);
         this._document.replacePatternPath(intersection.pathCrossed, splitPaths);
-        return splitPaths[1].getStartPoint();
+        return splitPaths[1].getPoints()[0];
     };
 
     private _resetTracing = (): void => {


### PR DESCRIPTION
Make sure throughout the code that PatternPaths that have matching endpoints share the same Point object instance in their points array for those endpoints. This means:
- computePoints in Segment should always return start and end points 
- handleIntersection returns the new endpoint on the split path

