### PR TITLE
Fix offset bug when starting a path on a bezier curve

### DIFF
--- a/src/canvas/Geometry/BezierCurve.tsx
+++ b/src/canvas/Geometry/BezierCurve.tsx
@@ -28,10 +28,10 @@ export class BezierCurve extends Curve {
         // TODO: this method may fail if the bezier curve is too long:
         // the tested point might slip in between 2 of the computed points        
         const NUMPOINTS = 100;
-        const points = this.computePoints(NUMPOINTS);
-        const indexOfClosestPoint = this._indexOfClosestPointOnCurve(point, points);
+        const pointsOnCurve = this.computePoints(NUMPOINTS);
+        const indexOfClosestPoint = this._indexOfClosestPointOnCurve(point, pointsOnCurve);
 
-        if (!point.isWithinRadius(points[indexOfClosestPoint], 10)){
+        if (!point.isWithinRadius(pointsOnCurve[indexOfClosestPoint], 10)){
             throw new Error("the point is not on the curve");
         } 
         

--- a/src/canvas/Geometry/BezierCurve.tsx
+++ b/src/canvas/Geometry/BezierCurve.tsx
@@ -28,22 +28,14 @@ export class BezierCurve extends Curve {
         // TODO: this method may fail if the bezier curve is too long:
         // the tested point might slip in between 2 of the computed points        
         const NUMPOINTS = 100;
-        const points = this.computePoints();
-        let minDist = point.distanceTo(points[0]);
-        let closestPointIndex = 0;
-        for (let i = 1; i < points.length; i++) {
-            const dist = point.distanceTo(points[i]);
-            if (dist < minDist) {
-                minDist = dist;
-                closestPointIndex = i;
-            }
-        }
+        const points = this.computePoints(NUMPOINTS);
+        const indexOfClosestPoint = this.indexOfClosestPointOnCurve(point, points);
 
-        if (!point.isWithinRadius(points[closestPointIndex], 10)){
+        if (!point.isWithinRadius(points[indexOfClosestPoint], 10)){
             throw new Error("the point is not on the curve");
         } 
         
-        return closestPointIndex / NUMPOINTS;
+        return indexOfClosestPoint / NUMPOINTS;
     };
 
     // Returns a point on the Bezier curve between its start point and

--- a/src/canvas/Geometry/BezierCurve.tsx
+++ b/src/canvas/Geometry/BezierCurve.tsx
@@ -29,7 +29,7 @@ export class BezierCurve extends Curve {
         // the tested point might slip in between 2 of the computed points        
         const NUMPOINTS = 100;
         const points = this.computePoints(NUMPOINTS);
-        const indexOfClosestPoint = this.indexOfClosestPointOnCurve(point, points);
+        const indexOfClosestPoint = this._indexOfClosestPointOnCurve(point, points);
 
         if (!point.isWithinRadius(points[indexOfClosestPoint], 10)){
             throw new Error("the point is not on the curve");

--- a/src/canvas/Geometry/BezierCurve.tsx
+++ b/src/canvas/Geometry/BezierCurve.tsx
@@ -29,19 +29,21 @@ export class BezierCurve extends Curve {
         // the tested point might slip in between 2 of the computed points        
         const NUMPOINTS = 100;
         const points = this.computePoints();
-        let index = -1;
-        for (let i = 0; i < points.length; i++) {
-            if (points[i].isWithinRadius(point, 10)){
-                index = i;
-                break;
+        let minDist = point.distanceTo(points[0]);
+        let closestPointIndex = 0;
+        for (let i = 1; i < points.length; i++) {
+            const dist = point.distanceTo(points[i]);
+            if (dist < minDist) {
+                minDist = dist;
+                closestPointIndex = i;
             }
         }
 
-        if (index === -1) {
+        if (!point.isWithinRadius(points[closestPointIndex], 10)){
             throw new Error("the point is not on the curve");
-        }
+        } 
         
-        return index / NUMPOINTS;
+        return closestPointIndex / NUMPOINTS;
     };
 
     // Returns a point on the Bezier curve between its start point and

--- a/src/canvas/Geometry/Curve.tsx
+++ b/src/canvas/Geometry/Curve.tsx
@@ -75,11 +75,11 @@ export abstract class Curve extends Segment {
     */
     isPointNearSegment = (point: Point, threshold: number): Point | null => {
         const NUMPOINTS = 100;
-        const points = this.computePoints(NUMPOINTS);
-        const indexOfClosestPoint = this._indexOfClosestPointOnCurve(point, points);
+        const pointsOnCurve = this.computePoints(NUMPOINTS);
+        const indexOfClosestPoint = this._indexOfClosestPointOnCurve(point, pointsOnCurve);
 
-        if (point.isWithinRadius(points[indexOfClosestPoint], threshold)) {
-            return points[indexOfClosestPoint];
+        if (point.isWithinRadius(pointsOnCurve[indexOfClosestPoint], threshold)) {
+            return pointsOnCurve[indexOfClosestPoint];
         } else {
             return null;
         }

--- a/src/canvas/Geometry/Curve.tsx
+++ b/src/canvas/Geometry/Curve.tsx
@@ -74,22 +74,27 @@ export abstract class Curve extends Segment {
      * and then checking if that point is within a radius at the given threshold.
     */
     isPointNearSegment = (point: Point, threshold: number): Point | null => {
-        const points = this.computePoints();
-        let minDist = point.distanceTo(points[0]);
-        let closestPoint = points[0];
-        for (let i = 1; i < points.length; i++) {
-            const dist = point.distanceTo(points[i]);
-            if (dist < minDist) {
-                minDist = dist;
-                closestPoint = points[i];
-            }
-        }
+        const points = this.computePoints(100);
+        const indexOfClosestPoint = this.indexOfClosestPointOnCurve(point, points);
 
-        if (point.isWithinRadius(closestPoint, threshold)) {
-            return closestPoint;
+        if (point.isWithinRadius(points[indexOfClosestPoint], threshold)) {
+            return points[indexOfClosestPoint];
         } else {
             return null;
         }
+    };
+
+    protected indexOfClosestPointOnCurve = (point: Point, pointsOnCurve: Point[]): number => {
+        let minDist = point.distanceTo(pointsOnCurve[0]);
+        let closestPointIndex = 0;
+        for (let i = 1; i < pointsOnCurve.length; i++) {
+            const dist = point.distanceTo(pointsOnCurve[i]);
+            if (dist < minDist) {
+                minDist = dist;
+                closestPointIndex = i;
+            }
+        }
+        return closestPointIndex;
     };
 
     protected lerp = (start: number, end: number, t: number): number => {

--- a/src/canvas/Geometry/Curve.tsx
+++ b/src/canvas/Geometry/Curve.tsx
@@ -68,20 +68,28 @@ export abstract class Curve extends Segment {
     };
 
     /* 
-     * Returns null if a points is not near the segement, otherwise it returns the closest
-     * point on the segement. Checks if a point is near the curve by computing a number of 
-     * points on that curve and then checking if the given point is within a radius at the 
-     * given threshold of each computed point.
+     * Returns null if a point is not near the segement, otherwise it returns the closest
+     * point on the segment. Checks if a point is near the curve by computing a number of 
+     * points on that curve, finding the point among those that is closest to the inputted point,
+     * and then checking if that point is within a radius at the given threshold.
     */
     isPointNearSegment = (point: Point, threshold: number): Point | null => {
         const points = this.computePoints();
-        for (let i = 0; i < points.length; i++) {
-            if (point.isWithinRadius(points[i], threshold)) {
-                return points[i];
+        let minDist = point.distanceTo(points[0]);
+        let closestPoint = points[0];
+        for (let i = 1; i < points.length; i++) {
+            const dist = point.distanceTo(points[i]);
+            if (dist < minDist) {
+                minDist = dist;
+                closestPoint = points[i];
             }
         }
 
-        return null;
+        if (point.isWithinRadius(closestPoint, threshold)) {
+            return closestPoint;
+        } else {
+            return null;
+        }
     };
 
     protected lerp = (start: number, end: number, t: number): number => {

--- a/src/canvas/Geometry/Curve.tsx
+++ b/src/canvas/Geometry/Curve.tsx
@@ -74,8 +74,9 @@ export abstract class Curve extends Segment {
      * and then checking if that point is within a radius at the given threshold.
     */
     isPointNearSegment = (point: Point, threshold: number): Point | null => {
-        const points = this.computePoints(100);
-        const indexOfClosestPoint = this.indexOfClosestPointOnCurve(point, points);
+        const NUMPOINTS = 100;
+        const points = this.computePoints(NUMPOINTS);
+        const indexOfClosestPoint = this._indexOfClosestPointOnCurve(point, points);
 
         if (point.isWithinRadius(points[indexOfClosestPoint], threshold)) {
             return points[indexOfClosestPoint];
@@ -84,7 +85,7 @@ export abstract class Curve extends Segment {
         }
     };
 
-    protected indexOfClosestPointOnCurve = (point: Point, pointsOnCurve: Point[]): number => {
+    protected _indexOfClosestPointOnCurve = (point: Point, pointsOnCurve: Point[]): number => {
         let minDist = point.distanceTo(pointsOnCurve[0]);
         let closestPointIndex = 0;
         for (let i = 1; i < pointsOnCurve.length; i++) {


### PR DESCRIPTION
Description of the bug:

When starting to draw a path on a curve, the snapping algorithm snaps the starting point of our new path approx. 10 pixels early on the the curve, because the algorithms were not looking for the best possible snapping position, just one that was 10 pixels or less away, and then returned.

Fix:

isPointNearSegment and findT now both go through all points on the curve to find the one that is closest to the mousedown event on the curve.