### PR TITLE
Bug Fix: starting a Freeline Path on an endpoint throws

### DIFF
--- a/src/canvas/TracingPaths/TracingPath.tsx
+++ b/src/canvas/TracingPaths/TracingPath.tsx
@@ -96,11 +96,11 @@ export abstract class TracingPath implements ITracingPath {
      * last point.
      */
     snapEndPoint = (patternPaths: PatternPath[]): boolean => {
-        const snapped = this._snapEndPoints(patternPaths, this._points.length - 1);
-        if (snapped) {
+        const updatedEndPoint = this._snapEndPoints(patternPaths, this._points.length - 1);
+        if (updatedEndPoint) {
             this._updatePath2D();
         }
-        return snapped;
+        return updatedEndPoint;
     };
 
     private _snapEndPoints = (patternPaths: PatternPath[], index: number): boolean => {

--- a/src/canvas/TracingPaths/TracingPath.tsx
+++ b/src/canvas/TracingPaths/TracingPath.tsx
@@ -123,7 +123,7 @@ export abstract class TracingPath implements ITracingPath {
             }
         }
 
-        if (updatedPoint) {
+        if (updatedPoint && this._lastIndexAddedToPath2D >= 0) {
             this._updatePath2D();
             return true;
         }

--- a/src/canvas/TracingPaths/TracingPath.tsx
+++ b/src/canvas/TracingPaths/TracingPath.tsx
@@ -96,7 +96,11 @@ export abstract class TracingPath implements ITracingPath {
      * last point.
      */
     snapEndPoint = (patternPaths: PatternPath[]): boolean => {
-        return this._snapEndPoints(patternPaths, this._points.length - 1);
+        const snapped = this._snapEndPoints(patternPaths, this._points.length - 1);
+        if (snapped) {
+            this._updatePath2D();
+        }
+        return snapped;
     };
 
     private _snapEndPoints = (patternPaths: PatternPath[], index: number): boolean => {
@@ -123,12 +127,7 @@ export abstract class TracingPath implements ITracingPath {
             }
         }
 
-        if (updatedPoint && this._lastIndexAddedToPath2D >= 0) {
-            this._updatePath2D();
-            return true;
-        }
-
-        return false;
+        return updatedPoint;
     };
 
     protected abstract _updatePath2D(): void;


### PR DESCRIPTION
Bug:

Starting a Freeline Path on an endpoint throws because _lastindexAddedToPath2D is still -1 when _snapEndPoints and then _updatePath2D are called.

Fix:

Prevent calling updatePath2D in TracingPath's _snapEndPoints if we don't have enough points