### PR TITLE
Fix bug in PathIntersection

### DIFF
--- a/src/canvas/TracingPaths/StraightLinePath.tsx
+++ b/src/canvas/TracingPaths/StraightLinePath.tsx
@@ -3,7 +3,9 @@ import { Point } from 'canvas/Geometry/Point';
 
 export class StraightLinePath extends TracingPath {
     protected _addPoint = (point: Point): void => {
-        this._points[1] = point;
+        if (!point.equals(this._points[0])) {
+            this._points[1] = point;
+        }
     };
 
     protected _updatePath2D = (): void => {


### PR DESCRIPTION
Don't add a point as the end point of a straight line path if it is the same as the start point.