### PR TITLE
Allowances

### DIFF
--- a/src/_tests/FaceFinder.test.tsx
+++ b/src/_tests/FaceFinder.test.tsx
@@ -8,14 +8,22 @@ test("find the inside face of a triangle", async () => {
     const p1 = new Point(0, 0);
     const p2 = new Point(1, 0);
     const p3 = new Point(1, 1);
-    const triangle = [new PatternPath(PatternPathType.Edge, [new LineSegment(p1, p2)]), 
-                      new PatternPath(PatternPathType.Edge, [new LineSegment(p2, p3)]), 
-                      new PatternPath(PatternPathType.Edge, [new LineSegment(p3, p1)])];
-    const reverseTriangle = [new PatternPath(PatternPathType.Edge, [new LineSegment(p2, p1)]), 
-                            new PatternPath(PatternPathType.Edge, [new LineSegment(p3, p2)]), 
-                            new PatternPath(PatternPathType.Edge, [new LineSegment(p1, p3)])];
-    expect(FaceFinder.FindFaces(triangle)).toEqual([[{"index": 0, "isReversed": false}, {"index": 1, "isReversed": false}, {"index": 2, "isReversed": false}]]);
-    expect(FaceFinder.FindFaces(reverseTriangle)).toEqual([[{"index": 0, "isReversed": true}, {"index": 1, "isReversed": true}, {"index": 2, "isReversed": true}]]);
+    const p1p2 = new PatternPath(PatternPathType.Edge, [new LineSegment(p1, p2)]);
+    const p2p3 = new PatternPath(PatternPathType.Edge, [new LineSegment(p2, p3)]);
+    const p3p1 = new PatternPath(PatternPathType.Edge, [new LineSegment(p3, p1)]);
+    const triangle = [p1p2, p2p3, p3p1];
+    let faces = FaceFinder.FindFaces(triangle);
+    expect(faces.length).toEqual(1);
+    expect(faces[0][0].equals(p1p2)).toBeTruthy();
+    expect(faces[0][1].equals(p2p3)).toBeTruthy();
+    expect(faces[0][2].equals(p3p1)).toBeTruthy();
+
+    const reverseTriangle = [p1p2.reversedClone(), p2p3.reversedClone(), p3p1.reversedClone()];
+    faces = FaceFinder.FindFaces(reverseTriangle);
+    expect(faces).toHaveLength(1);
+    expect(faces[0][0].equals(p1p2)).toBeTruthy();
+    expect(faces[0][1].equals(p2p3)).toBeTruthy();
+    expect(faces[0][2].equals(p3p1)).toBeTruthy();
 });
 
 test("find the inside faces of a split square", async () => {
@@ -23,13 +31,18 @@ test("find the inside faces of a split square", async () => {
     const p2 = new Point(1, 0);
     const p3 = new Point(1, 1);
     const p4 = new Point(0, 1);
-    const splitSquare = [new PatternPath(PatternPathType.Edge, [new LineSegment(p1, p2)]), 
-                         new PatternPath(PatternPathType.Edge, [new LineSegment(p3, p2)]), 
-                         new PatternPath(PatternPathType.Edge, [new LineSegment(p3, p1)]), 
-                         new PatternPath(PatternPathType.Edge, [new LineSegment(p3, p4)]), 
-                         new PatternPath(PatternPathType.Edge, [new LineSegment(p1, p4)])];
-    const result = FaceFinder.FindFaces(splitSquare);
-    expect(result).toContainEqual([{"index": 0, "isReversed": false}, {"index": 1, "isReversed": true}, {"index": 2, "isReversed": false}]);
-    expect(result).toContainEqual([{"index": 2, "isReversed": true}, {"index": 3, "isReversed": false}, {"index": 4, "isReversed": true}]);
-    expect(result).toHaveLength(2);
+    const p1p2 = new PatternPath(PatternPathType.Edge, [new LineSegment(p1, p2)]);
+    const p3p2 = new PatternPath(PatternPathType.Edge, [new LineSegment(p3, p2)]);
+    const p3p1 = new PatternPath(PatternPathType.Edge, [new LineSegment(p3, p1)]);
+    const p3p4 = new PatternPath(PatternPathType.Edge, [new LineSegment(p3, p4)]);
+    const p1p4 = new PatternPath(PatternPathType.Edge, [new LineSegment(p1, p4)]);
+    const splitSquare = [p1p2, p3p2, p3p1, p3p4, p1p4];
+    const faces = FaceFinder.FindFaces(splitSquare);
+    expect(faces).toHaveLength(2);
+    expect(faces[0][0].equals(p1p2)).toBeTruthy();
+    expect(faces[0][1].equals(p3p2.reversedClone())).toBeTruthy();
+    expect(faces[0][2].equals(p3p1)).toBeTruthy();
+    expect(faces[1][0].equals(p3p1.reversedClone())).toBeTruthy();
+    expect(faces[1][1].equals(p3p4)).toBeTruthy();
+    expect(faces[1][2].equals(p1p4.reversedClone())).toBeTruthy();
 });

--- a/src/_tests/FaceFinder.test.tsx
+++ b/src/_tests/FaceFinder.test.tsx
@@ -14,8 +14,8 @@ test("find the inside face of a triangle", async () => {
     const reverseTriangle = [new PatternPath(PatternPathType.Edge, [new LineSegment(p2, p1)]), 
                             new PatternPath(PatternPathType.Edge, [new LineSegment(p3, p2)]), 
                             new PatternPath(PatternPathType.Edge, [new LineSegment(p1, p3)])];
-    expect(FaceFinder.FindFaces(triangle)).toEqual([[0, 1, 2]]);
-    expect(FaceFinder.FindFaces(reverseTriangle)).toEqual([[0, 1, 2]]);
+    expect(FaceFinder.FindFaces(triangle)).toEqual([[{"index": 0, "isReversed": false}, {"index": 1, "isReversed": false}, {"index": 2, "isReversed": false}]]);
+    expect(FaceFinder.FindFaces(reverseTriangle)).toEqual([[{"index": 0, "isReversed": true}, {"index": 1, "isReversed": true}, {"index": 2, "isReversed": true}]]);
 });
 
 test("find the inside faces of a split square", async () => {
@@ -29,7 +29,7 @@ test("find the inside faces of a split square", async () => {
                          new PatternPath(PatternPathType.Edge, [new LineSegment(p3, p4)]), 
                          new PatternPath(PatternPathType.Edge, [new LineSegment(p1, p4)])];
     const result = FaceFinder.FindFaces(splitSquare);
-    expect(result).toContainEqual([0, 1, 2]);
-    expect(result).toContainEqual([2, 3, 4]);
+    expect(result).toContainEqual([{"index": 0, "isReversed": false}, {"index": 1, "isReversed": true}, {"index": 2, "isReversed": false}]);
+    expect(result).toContainEqual([{"index": 2, "isReversed": true}, {"index": 3, "isReversed": false}, {"index": 4, "isReversed": true}]);
     expect(result).toHaveLength(2);
 });

--- a/src/canvas/Document.tsx
+++ b/src/canvas/Document.tsx
@@ -149,8 +149,8 @@ export class Document implements IDocument {
     /**
      * Sets the allowance sizes to 0 inches for folds, the input edgeAllowance 
      * for edges and the input seam allowance for seams. If parameters are
-     * omitted, the edge allowance will be set to a default of 2 inches 
-     * and the seam allowance to a default of 1 inch. The sizes are stored in
+     * omitted, the edge allowance will be set to a default of 5/8 inch 
+     * and the seam allowance to a default of 5/8 inch. The sizes are stored in
      * pixels in the allowanceSizes map data field.
      * 
      * Warning: every time this method is called the old data is erased.
@@ -164,9 +164,9 @@ export class Document implements IDocument {
         }
 
         this._allowanceSizes = new Map();
-        this._allowanceSizes.set(PatternPathType.Edge, (edgeAllowance || 2) * this._sizeRatio);
+        this._allowanceSizes.set(PatternPathType.Edge, (edgeAllowance || 0.625) * this._sizeRatio);
         this._allowanceSizes.set(PatternPathType.Fold, 0);
-        this._allowanceSizes.set(PatternPathType.Seam, (seamAllowance || 1) * this._sizeRatio);
+        this._allowanceSizes.set(PatternPathType.Seam, (seamAllowance || 0.625) * this._sizeRatio);
     };
 
     prepPatternPieces = (): void => {

--- a/src/canvas/Document.tsx
+++ b/src/canvas/Document.tsx
@@ -186,13 +186,13 @@ export class Document implements IDocument {
         const patternPieces = faces.map(face => (
             new PatternPiece(face.map((edge) => {
                 if (edge.isReversed) {
-                    return this._patternPaths[edge.index].clone();
-                } else {
                     return this._patternPaths[edge.index].reversedClone();
+                } else {
+                    return this._patternPaths[edge.index].clone();
                 }
             }))
         ));
-        
+
         return patternPieces;
     };
 

--- a/src/canvas/Document.tsx
+++ b/src/canvas/Document.tsx
@@ -190,7 +190,9 @@ export class Document implements IDocument {
         this._patternPaths = this._spreadPatternPieces(this._patternPieces);
     };
 
-    // Temporary method to inspect pattern pieces and allowances on final review page while developping.
+    /**
+     * Method for debugging. Allows us to inspect pattern pieces an allowances visually.
+     */ 
     private _spreadPatternPieces = (patternPieces: PatternPiece[]): PatternPath[] => {
         let result: PatternPath[] = [];
 

--- a/src/canvas/Document.tsx
+++ b/src/canvas/Document.tsx
@@ -163,7 +163,7 @@ export class Document implements IDocument {
      */
     setAllowanceSizes = (edgeAllowance?: number, seamAllowance?: number): void => {
         if (!this._sizeRatio) {
-            throw new Error("the size ratio was not yet defined for this pattern.");
+            throw new Error("The size ratio was not yet defined for this pattern.");
         }
 
         this._allowanceSizes = new Map();
@@ -174,6 +174,11 @@ export class Document implements IDocument {
 
     // Precondition: arePatternPiecesEnclosed returned true 
     findPatternPieces = (): void => {
+        const allowanceSizes = this._allowanceSizes;
+        if (allowanceSizes === null) {
+            throw new Error("The allowance sizes were not defined yet for this pattern");
+        }
+        
         const faces = FaceFinder.FindFaces(this._patternPaths);
         
         this._patternPieces = faces.map(face => (
@@ -183,7 +188,7 @@ export class Document implements IDocument {
                 } else {
                     return this._patternPaths[edge.index].clone();
                 }
-            }))
+            }), allowanceSizes)
         ));
 
         // Temporary step to inspect pattern pieces and allowances on final review page while developping.

--- a/src/canvas/Document.tsx
+++ b/src/canvas/Document.tsx
@@ -9,8 +9,9 @@ export class Document implements IDocument {
     private _patternPaths: PatternPath[];
     private _patternPathsTrash: IPatternPathTrash[];
     private _sizeRatio: null | number; // in pixels per inch
-    private _allowanceSizes: Map<PatternPathType, number> | null; // allowance sizes in pixels
     private _patternPieces: PatternPiece[] | null;
+    private _allowanceSizes: Map<PatternPathType, number> | null; // allowance sizes in pixels
+    
 
     constructor () {
         this._patternPaths = new Array<PatternPath>();

--- a/src/canvas/Document.tsx
+++ b/src/canvas/Document.tsx
@@ -172,7 +172,7 @@ export class Document implements IDocument {
     };
 
     // Precondition: arePatternPiecesEnclosed returned true 
-    computePatternPieces = (): void => {
+    findPatternPieces = (): void => {
         const faces = FaceFinder.FindFaces(this._patternPaths);
         
         this._patternPieces = faces.map(face => (

--- a/src/canvas/Document.tsx
+++ b/src/canvas/Document.tsx
@@ -172,7 +172,7 @@ export class Document implements IDocument {
     prepPatternPieces = (): void => {
         const patternPieces: PatternPiece[] = this._findPatternPieces();
         patternPieces.forEach(piece => {
-            piece.addAllowances();
+            piece.computeAllowancePaths();
         });
 
         // Temporary step to inspect pattern pieces and allowances on final review page while developping.

--- a/src/canvas/Document.tsx
+++ b/src/canvas/Document.tsx
@@ -17,8 +17,8 @@ export class Document implements IDocument {
         this._patternPaths = new Array<PatternPath>();
         this._patternPathsTrash = [];
         this._sizeRatio = null;
-        this._allowanceSizes = null;
         this._patternPieces = null;
+        this._allowanceSizes = null;
     }
 
     getPatternPaths = (): PatternPath[] => {

--- a/src/canvas/Document.tsx
+++ b/src/canvas/Document.tsx
@@ -10,12 +10,14 @@ export class Document implements IDocument {
     private _patternPathsTrash: IPatternPathTrash[];
     private _sizeRatio: null | number; // in pixels per inch
     private _allowanceSizes: Map<PatternPathType, number> | null; // allowance sizes in pixels
+    private _patternPieces: PatternPiece[] | null;
 
     constructor () {
         this._patternPaths = new Array<PatternPath>();
         this._patternPathsTrash = [];
         this._sizeRatio = null;
         this._allowanceSizes = null;
+        this._patternPieces = null;
     }
 
     getPatternPaths = (): PatternPath[] => {
@@ -169,21 +171,11 @@ export class Document implements IDocument {
         this._allowanceSizes.set(PatternPathType.Seam, (seamAllowance || 0.625) * this._sizeRatio);
     };
 
-    prepPatternPieces = (): void => {
-        const patternPieces: PatternPiece[] = this._findPatternPieces();
-        patternPieces.forEach(piece => {
-            piece.computeAllowancePaths();
-        });
-
-        // Temporary step to inspect pattern pieces and allowances on final review page while developping.
-        this._patternPaths = this._spreadPatternPieces(patternPieces);
-    };
-    
     // Precondition: arePatternPiecesEnclosed returned true 
-    private _findPatternPieces = (): PatternPiece[] => {
+    computePatternPieces = (): void => {
         const faces = FaceFinder.FindFaces(this._patternPaths);
         
-        const patternPieces = faces.map(face => (
+        this._patternPieces = faces.map(face => (
             new PatternPiece(face.map((edge) => {
                 if (edge.isReversed) {
                     return this._patternPaths[edge.index].reversedClone();
@@ -193,7 +185,8 @@ export class Document implements IDocument {
             }))
         ));
 
-        return patternPieces;
+        // Temporary step to inspect pattern pieces and allowances on final review page while developping.
+        this._patternPaths = this._spreadPatternPieces(this._patternPieces);
     };
 
     // Temporary method to inspect pattern pieces and allowances on final review page while developping.

--- a/src/canvas/Document.tsx
+++ b/src/canvas/Document.tsx
@@ -182,13 +182,7 @@ export class Document implements IDocument {
         const faces = FaceFinder.FindFaces(this._patternPaths);
         
         this._patternPieces = faces.map(face => (
-            new PatternPiece(face.map((edge) => {
-                if (edge.isReversed) {
-                    return this._patternPaths[edge.index].reversedClone();
-                } else {
-                    return this._patternPaths[edge.index].clone();
-                }
-            }), allowanceSizes)
+            new PatternPiece(face, allowanceSizes)
         ));
 
         // Temporary step to inspect pattern pieces and allowances on final review page while developping.

--- a/src/canvas/Enums.tsx
+++ b/src/canvas/Enums.tsx
@@ -3,6 +3,7 @@ export enum PatternPathType {
     Seam,
     Fold,
     Edge,
+    Allowance
 }
 
 export enum ToolType {

--- a/src/canvas/Geometry/ArcCurve.tsx
+++ b/src/canvas/Geometry/ArcCurve.tsx
@@ -136,6 +136,12 @@ export class ArcCurve extends Curve {
         return Math.abs(this.startAngle - this.endAngle) * this.radius;
     };
 
+    getTangent = (t: number): Vector => {
+        const x = -1 * (this.endAngle - this.startAngle) * this.radius * Math.sin(this.lerp(this.startAngle, this.endAngle, t));
+        const y = (this.endAngle - this.startAngle) * this.radius * Math.cos(this.lerp(this.startAngle, this.endAngle, t));
+        return new Vector(x, y);
+    };
+
     getOffsetSegments = (distance: number): Segment[] => {
         const tangentAtStart = this.getTangent(0);
         const displacementOfStart = Vector.findPerpVector(tangentAtStart).normalize().multiplyByScalar(distance);
@@ -157,12 +163,6 @@ export class ArcCurve extends Curve {
         this.control = Point.translate(this.control, displacement);
         this.end = Point.translate(this.end, displacement);
         this.center = Point.translate(this.center, displacement);
-    };
-
-    getTangent = (t: number): Vector => {
-        const x = -1 * (this.endAngle - this.startAngle) * this.radius * Math.sin(this.lerp(this.startAngle, this.endAngle, t));
-        const y = (this.endAngle - this.startAngle) * this.radius * Math.cos(this.lerp(this.startAngle, this.endAngle, t));
-        return new Vector(x, y);
     };
 
     clone = (): ArcCurve => {

--- a/src/canvas/Geometry/ArcCurve.tsx
+++ b/src/canvas/Geometry/ArcCurve.tsx
@@ -144,10 +144,10 @@ export class ArcCurve extends Curve {
 
     getOffsetSegments = (distance: number): Segment[] => {
         const tangentAtStart = this.getTangent(0);
-        const displacementOfStart = Vector.findPerpVector(tangentAtStart).normalize().multiplyByScalar(distance);
+        const displacementOfStart = Vector.findOpposite(Vector.findPerpVector(tangentAtStart)).normalize().multiplyByScalar(distance);
 
         const tangentAtEnd = this.getTangent(1);
-        const displacementOfEnd = Vector.findPerpVector(tangentAtEnd).normalize().multiplyByScalar(distance);
+        const displacementOfEnd = Vector.findOpposite(Vector.findPerpVector(tangentAtEnd)).normalize().multiplyByScalar(distance);
 
         const result = this.clone();
         result.start = Point.translate(this.start, displacementOfStart);

--- a/src/canvas/Geometry/ArcCurve.tsx
+++ b/src/canvas/Geometry/ArcCurve.tsx
@@ -172,4 +172,8 @@ export class ArcCurve extends Curve {
     reversedClone = (): ArcCurve => {
         return new ArcCurve(this.end, this.start, this.control);
     };
+
+    protected _equals = (other: Segment): boolean => {
+        return (other instanceof ArcCurve) && this.control.equals(other.control);
+    };
 }

--- a/src/canvas/Geometry/BezierCurve.tsx
+++ b/src/canvas/Geometry/BezierCurve.tsx
@@ -1,5 +1,7 @@
 import { Point } from './Point';
 import { Curve } from './Curve';
+import { Segment } from './Segment';
+import { Vector } from './Vector';
 
 export class BezierCurve extends Curve {
     // Precondition: split is a point on the curve.
@@ -59,5 +61,49 @@ export class BezierCurve extends Curve {
     // Overrides the abstract method in parent class.
     drawTo = (path: Path2D): void => {
         path.quadraticCurveTo(this.control.x, this.control.y, this.end.x, this.end.y);   
+    };
+
+    getOffsetSegments = (distance: number): Segment[] => {
+        // Compute offset points
+        const offsetPoints: Point[] = [];
+        const NUMPOINTS = 20;
+        const numSegments = NUMPOINTS - 1;
+        for (let t = 0; t <= 1; t += (1 / numSegments)) {
+            const pointOnBezier = this._computePoint(t);
+            const displacement = Vector.findPerpVector(this.getTangent(t)).normalize().multiplyByScalar(distance);
+            offsetPoints.push(Point.translate(pointOnBezier, displacement));
+        }
+
+        // Construct an array of BezierCurves that link the offset points
+        const result: Segment[] = [];
+        let middle = Point.computeMiddlePoint(offsetPoints[1], offsetPoints[2]);
+        result.push(new BezierCurve(offsetPoints[0], middle, offsetPoints[1]));
+        for (let i = 1; i < NUMPOINTS - 3; i++) {
+            const prevMiddle = middle;
+            middle = Point.computeMiddlePoint(offsetPoints[i + 1], offsetPoints[i + 2]);
+            result.push(new BezierCurve(prevMiddle, middle, offsetPoints[i + 1]));
+        }
+        result.push(new BezierCurve(middle, offsetPoints[NUMPOINTS - 1], offsetPoints[NUMPOINTS - 2]));
+        return result;
+    };
+
+    translate = (displacement: Vector): void => {
+        this.start = Point.translate(this.start, displacement);
+        this.control = Point.translate(this.control, displacement);
+        this.end = Point.translate(this.end, displacement);
+    };
+
+    getTangent = (t: number): Vector => {
+        const x = -2 * (1 - t) * this.start.x + (2 - 4 * t) * this.control.x + 2 * t * this.end.x;
+        const y = -2 * (1 - t) * this.start.y + (2 - 4 * t) * this.control.y + 2 * t * this.end.y;
+        return new Vector(x, y);
+    };
+
+    clone = (): BezierCurve => {
+        return new BezierCurve(this.start, this.end, this.control);
+    };
+
+    reversedClone = (): BezierCurve => {
+        return new BezierCurve(this.end, this.start, this.control);
     };
 }

--- a/src/canvas/Geometry/BezierCurve.tsx
+++ b/src/canvas/Geometry/BezierCurve.tsx
@@ -62,6 +62,12 @@ export class BezierCurve extends Curve {
     drawTo = (path: Path2D): void => {
         path.quadraticCurveTo(this.control.x, this.control.y, this.end.x, this.end.y);   
     };
+    
+    getTangent = (t: number): Vector => {
+        const x = -2 * (1 - t) * this.start.x + (2 - 4 * t) * this.control.x + 2 * t * this.end.x;
+        const y = -2 * (1 - t) * this.start.y + (2 - 4 * t) * this.control.y + 2 * t * this.end.y;
+        return new Vector(x, y);
+    };
 
     getOffsetSegments = (distance: number): Segment[] => {
         // Compute offset points
@@ -91,12 +97,6 @@ export class BezierCurve extends Curve {
         this.start = Point.translate(this.start, displacement);
         this.control = Point.translate(this.control, displacement);
         this.end = Point.translate(this.end, displacement);
-    };
-
-    getTangent = (t: number): Vector => {
-        const x = -2 * (1 - t) * this.start.x + (2 - 4 * t) * this.control.x + 2 * t * this.end.x;
-        const y = -2 * (1 - t) * this.start.y + (2 - 4 * t) * this.control.y + 2 * t * this.end.y;
-        return new Vector(x, y);
     };
 
     clone = (): BezierCurve => {

--- a/src/canvas/Geometry/BezierCurve.tsx
+++ b/src/canvas/Geometry/BezierCurve.tsx
@@ -106,4 +106,8 @@ export class BezierCurve extends Curve {
     reversedClone = (): BezierCurve => {
         return new BezierCurve(this.end, this.start, this.control);
     };
+
+    protected _equals = (other: Segment): boolean => {
+        return (other instanceof BezierCurve) && this.control.equals(other.control);
+    };
 }

--- a/src/canvas/Geometry/BezierCurve.tsx
+++ b/src/canvas/Geometry/BezierCurve.tsx
@@ -76,7 +76,7 @@ export class BezierCurve extends Curve {
         const numSegments = NUMPOINTS - 1;
         for (let t = 0; t <= 1; t += (1 / numSegments)) {
             const pointOnBezier = this._computePoint(t);
-            const displacement = Vector.findPerpVector(this.getTangent(t)).normalize().multiplyByScalar(distance);
+            const displacement = Vector.findOpposite(Vector.findPerpVector(this.getTangent(t))).normalize().multiplyByScalar(distance);
             offsetPoints.push(Point.translate(pointOnBezier, displacement));
         }
 

--- a/src/canvas/Geometry/Curve.tsx
+++ b/src/canvas/Geometry/Curve.tsx
@@ -1,6 +1,5 @@
 import { Point } from './Point';
 import { Segment } from './Segment';
-import { Vector } from './Vector';
 
 export abstract class Curve extends Segment {
     protected control: Point;
@@ -46,25 +45,6 @@ export abstract class Curve extends Segment {
         //       one. Everytime we get a new point, we first check if it is close enough to the 
         //       previous point, and if it is not we ask for another point that is closer on 
         //       the curve instead. This would allow us to bound our error on the total length. 
-    };
-
-    /**
-     * Returns a vector that is tangent to the curve at the position indicated by
-     * the parameter t.
-     * 
-     * @param t Describes the position on the curve where we want the tangent vector.
-     *          t should be equal to 0 or 1, 0 for the start of the curve, 1 for the end
-     */
-    getTangent = (t: number): Vector => {
-        // TODO: for seam allowances, implement this for all values of t between 0 and 1
-        if (!(t === 0 || t === 1)) {
-            throw new Error();
-        }
-        if (t === 0) {
-            return Vector.vectorBetweenPoints(this.start, this.control);
-        } else { // t === 1
-            return Vector.vectorBetweenPoints(this.control, this.end);
-        }
     };
 
     /* 

--- a/src/canvas/Geometry/FaceFinder.tsx
+++ b/src/canvas/Geometry/FaceFinder.tsx
@@ -95,11 +95,9 @@ export class FaceFinder {
         // graph formula, reduced by one because we excluded the face 
         // that is the outside of the graph.
         if (faces.length < ((2 - vertices.length + paths.length) - 1)) {
-            // Todo: throw error
-            console.log("The number of faces found by the findFaces algorithm is too low");
+            throw new Error("The number of faces found by the findFaces algorithm is too low");
         } else if (faces.length > ((2 - vertices.length + paths.length) - 1)) {
-            // Todo: throw error
-            console.log("The number of faces found by the findFaces algorithm is too high");
+            throw new Error("The number of faces found by the findFaces algorithm is too high");
         }
 
         return faces;

--- a/src/canvas/Geometry/LineSegment.tsx
+++ b/src/canvas/Geometry/LineSegment.tsx
@@ -135,4 +135,27 @@ export class LineSegment extends Segment {
         
         return new Point(xIntersectionPoint, yIntersectionPoint);
     };
+
+    getOffsetSegments = (distance: number): Segment[] => {
+        const displacement = Vector.findPerpVector(this.getTangent(0));
+        displacement.normalize();
+        displacement.multiplyByScalar(distance);
+
+        const result = this.clone();
+        result.translate(displacement);
+        return [result];
+    };
+
+    translate = (displacement: Vector): void => {
+        this.start = Point.translate(this.start, displacement);
+        this.end = Point.translate(this.end, displacement);
+    };
+
+    clone = (): LineSegment => {
+        return new LineSegment(this.start, this.end);
+    };
+
+    reversedClone = (): LineSegment => {
+        return new LineSegment(this.end, this.start);
+    };
 }

--- a/src/canvas/Geometry/LineSegment.tsx
+++ b/src/canvas/Geometry/LineSegment.tsx
@@ -156,4 +156,8 @@ export class LineSegment extends Segment {
     reversedClone = (): LineSegment => {
         return new LineSegment(this.end, this.start);
     };
+
+    protected _equals = (other: Segment): boolean => {
+        return (other instanceof LineSegment);
+    };
 }

--- a/src/canvas/Geometry/LineSegment.tsx
+++ b/src/canvas/Geometry/LineSegment.tsx
@@ -137,9 +137,7 @@ export class LineSegment extends Segment {
     };
 
     getOffsetSegments = (distance: number): Segment[] => {
-        const displacement = Vector.findPerpVector(this.getTangent(0));
-        displacement.normalize();
-        displacement.multiplyByScalar(distance);
+        const displacement = Vector.findOpposite(Vector.findPerpVector(this.getTangent(0))).normalize().multiplyByScalar(distance);
 
         const result = this.clone();
         result.translate(displacement);

--- a/src/canvas/Geometry/Segment.tsx
+++ b/src/canvas/Geometry/Segment.tsx
@@ -74,4 +74,22 @@ export abstract class Segment {
     abstract clone(): Segment;
     
     abstract reversedClone(): Segment;
+
+    equals = (other: Segment): boolean => {
+        if (this === other) {
+            return true;
+        }
+
+        if (!this.start.equals(other.start)) {
+            return false;
+        }
+
+        if (!this.end.equals(other.end)) {
+            return false;
+        }
+
+        return this._equals(other);
+    };
+
+    protected abstract _equals(other: Segment): boolean;
 }

--- a/src/canvas/Geometry/Segment.tsx
+++ b/src/canvas/Geometry/Segment.tsx
@@ -72,5 +72,6 @@ export abstract class Segment {
     abstract translate(displacement: Vector): void;
 
     abstract clone(): Segment;
+    
     abstract reversedClone(): Segment;
 }

--- a/src/canvas/Geometry/Segment.tsx
+++ b/src/canvas/Geometry/Segment.tsx
@@ -26,7 +26,7 @@ export abstract class Segment {
     abstract getLength(): number;
     
     /**
-     * Returns a vector that is tangent to the curve at the position indicated by
+     * Returns a vector that is tangent to the segment at the position indicated by
      * the parameter t.
      * 
      * @param t Describes the position on the curve where we want the tangent vector.

--- a/src/canvas/Geometry/Segment.tsx
+++ b/src/canvas/Geometry/Segment.tsx
@@ -25,6 +25,13 @@ export abstract class Segment {
 
     abstract getLength(): number;
     
+    /**
+     * Returns a vector that is tangent to the curve at the position indicated by
+     * the parameter t.
+     * 
+     * @param t Describes the position on the curve where we want the tangent vector.
+     *          t should be equal to 0 or 1, 0 for the start of the curve, 1 for the end
+     */
     abstract getTangent(t: number): Vector;
 
     /**
@@ -58,4 +65,11 @@ export abstract class Segment {
     abstract isPointNearSegment (point: Point, threshold: number): Point | null;
 
     abstract drawTo(path: Path2D): void;
+
+    abstract getOffsetSegments(distance: number): Segment[];
+
+    abstract translate(displacement: Vector): void;
+
+    abstract clone(): Segment;
+    abstract reversedClone(): Segment;
 }

--- a/src/canvas/Geometry/Segment.tsx
+++ b/src/canvas/Geometry/Segment.tsx
@@ -30,7 +30,8 @@ export abstract class Segment {
      * the parameter t.
      * 
      * @param t Describes the position on the curve where we want the tangent vector.
-     *          t should be equal to 0 or 1, 0 for the start of the curve, 1 for the end
+     *          t should be between 0 and 1 inclusively, 0 for the start of the curve,
+     *          1 for the end
      */
     abstract getTangent(t: number): Vector;
 

--- a/src/canvas/PathIntersection.tsx
+++ b/src/canvas/PathIntersection.tsx
@@ -33,7 +33,7 @@ export class PathIntersection {
 
             // If the intersection we find is within a 10 pt raidus of the first point of this path, 
             // keep looking for intersections. 
-            const intersection = PathIntersection._findIntersectionOfLineSegmentAndPath(thisLineSeg, thatPath);
+            const intersection = PathIntersection.findIntersectionOfLineSegmentAndPath(thisLineSeg, thatPath);
             if (intersection && !intersection.point.isWithinRadius(pointsOnThisPath[0], 10)) {
                 return intersection;
             }
@@ -71,14 +71,14 @@ export class PathIntersection {
      * 
      * Ignores intersection points that are on the endpoints of the path.
      */
-    private static _findIntersectionOfLineSegmentAndPath = (thisLineSeg: LineSegment, path: PatternPath): IIntersection | null => {
+    static findIntersectionOfLineSegmentAndPath = (thisLineSeg: LineSegment, path: PatternPath): IIntersection | null => {
         // Threshold for checking if a point is on a line. Range from 0 to 1, with 0 being the tightest and 1 being the loosest.
         const THRESHOLD = .01;
         const segments = path.getSegments();
         for (let segmentIndex = 0; segmentIndex < segments.length; segmentIndex++) {
             const segment = segments[segmentIndex];
             const segmentPoints = segment.getPoints();
-            for (let j = 1; j < segmentPoints.length; j++ ) {
+            for (let j = 1; j < segmentPoints.length; j++) {
                 const thatLineSeg = new LineSegment(segmentPoints[j], segmentPoints[j - 1]);
                 const intersectionPoint = LineSegment.findIntersectionPointOfTwoLines(thisLineSeg, thatLineSeg, true, THRESHOLD);
                 if (intersectionPoint && !intersectionPoint.equals(path.getStart()) && !intersectionPoint.equals(path.getEnd())) {

--- a/src/canvas/PatternPaths/AllowanceFinder.tsx
+++ b/src/canvas/PatternPaths/AllowanceFinder.tsx
@@ -1,0 +1,37 @@
+import { PatternPath } from "./PatternPath";
+import { Point } from "canvas/Geometry/Point";
+import { Segment } from "canvas/Geometry/Segment";
+import { LineSegment } from "canvas/Geometry/LineSegment";
+import { PatternPathType } from "canvas/Enums";
+
+export class AllowanceFinder {
+    static FindAllowance = (path: PatternPath, allowanceSize: number): PatternPath => {
+        if (path.getType() === PatternPathType.Allowance) {
+            throw new Error("Cannot find the allowance of an allowance.");
+        }
+        
+        // Get the path that is offset from this one
+        let offsetSegments: Segment[] = [];
+        path.getSegments().forEach(segment => {
+            offsetSegments = offsetSegments.concat(segment.getOffsetSegments(allowanceSize));
+        });
+        const lengthOfLineSegmentProlongations = 200;
+    
+        // Add a line segment at the beginning of the offset path,
+        // following the tangent of the offset at that point  
+        const firstSegment = offsetSegments[0];      
+        const p1 = firstSegment.getStart();
+        const p2 = Point.translate(p1, firstSegment.getTangent(0).normalize().multiplyByScalar(-1 * lengthOfLineSegmentProlongations));
+        
+        // Add a line segment at the end of the offset path,
+        // following the tangent of the offset at that point
+        const lastSegment = offsetSegments[offsetSegments.length - 1];
+        const q1 = lastSegment.getEnd();
+        const q2 = Point.translate(q1, lastSegment.getTangent(1).normalize().multiplyByScalar(lengthOfLineSegmentProlongations));
+        
+        let result: Segment[] = [new LineSegment(p2, p1)];
+        result = result.concat(offsetSegments);
+        result.push(new LineSegment(q1, q2));
+        return new PatternPath(PatternPathType.Allowance, result);
+    };
+}

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -97,27 +97,6 @@ export class PatternPath implements IPatternPath {
         this._path2D = this._computePath2D();
     };
 
-    private _splitSegments = (point: Point, segmentIndex: number): Segment[][] => {
-        const segmentToSplit = this._segments[segmentIndex];
-        const splitSegments = segmentToSplit.split(point);
-        if (splitSegments.length !== 2) {
-            throw new Error("Split did not return correct number of segments");
-        }
-        
-        const segmentsBeforePoint = [];
-        for (let i = 0; i < segmentIndex; i++) {
-            segmentsBeforePoint.push(this._segments[i]);
-        }
-        segmentsBeforePoint.push(splitSegments[0]);
-
-        const segmentsAfterPoint = [splitSegments[1]];
-        for (let i = segmentIndex + 1; i < this._segments.length; i++) {
-            segmentsAfterPoint.push(this._segments[i]);
-        }
-        
-        return [segmentsBeforePoint, segmentsAfterPoint];
-    };
-
     addSegment = (newSegment: Segment): void => {
         this._segments.push(newSegment);
         this._points = this._computePoints();
@@ -203,5 +182,26 @@ export class PatternPath implements IPatternPath {
             segment.drawTo(path2D);
         });
         return path2D; 
+    };
+
+    private _splitSegments = (point: Point, segmentIndex: number): Segment[][] => {
+        const segmentToSplit = this._segments[segmentIndex];
+        const splitSegments = segmentToSplit.split(point);
+        if (splitSegments.length !== 2) {
+            throw new Error("Split did not return correct number of segments");
+        }
+        
+        const segmentsBeforePoint = [];
+        for (let i = 0; i < segmentIndex; i++) {
+            segmentsBeforePoint.push(this._segments[i]);
+        }
+        segmentsBeforePoint.push(splitSegments[0]);
+
+        const segmentsAfterPoint = [splitSegments[1]];
+        for (let i = segmentIndex + 1; i < this._segments.length; i++) {
+            segmentsAfterPoint.push(this._segments[i]);
+        }
+        
+        return [segmentsBeforePoint, segmentsAfterPoint];
     };
 }

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -83,18 +83,19 @@ export class PatternPath implements IPatternPath {
     getAllowance = (): PatternPath => {
         // Get the path that is offset from this one
         const offsetSegments = this._getOffsetSegments();
+        const lengthOfLineProlongations = 100;
 
         // Add a line segment at the beginning of the offset path,
         // following the tangent of the offset at that point  
-        const first = offsetSegments[0];      
-        const p1 = first.getStart();
-        const p2 = Point.translate(p1, first.getTangent(0).normalize().multiplyByScalar(-100));
+        const firstSegment = offsetSegments[0];      
+        const p1 = firstSegment.getStart();
+        const p2 = Point.translate(p1, firstSegment.getTangent(0).normalize().multiplyByScalar(-1 * lengthOfLineProlongations));
         
         // Add a line segment at the end of the offset path,
         // following the tangent of the offset at that point
-        const last = offsetSegments[offsetSegments.length - 1];
-        const q1 = last.getEnd();
-        const q2 = Point.translate(q1, last.getTangent(1).normalize().multiplyByScalar(100));
+        const lastSegment = offsetSegments[offsetSegments.length - 1];
+        const q1 = lastSegment.getEnd();
+        const q2 = Point.translate(q1, lastSegment.getTangent(1).normalize().multiplyByScalar(lengthOfLineProlongations));
         
         let result: Segment[] = [new LineSegment(p2, p1)];
         result = result.concat(offsetSegments);

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -70,8 +70,7 @@ export class PatternPath implements IPatternPath {
     splitAtPoint = (point: Point, segmentIndex: number): PatternPath[] => {
         const splitSegments = this._splitSegments(point, segmentIndex);
         return [new PatternPath(this._type, splitSegments[0]),
-                new PatternPath(this._type, splitSegments[1])];    
-        
+                new PatternPath(this._type, splitSegments[1])];
     };
 
     /**
@@ -91,6 +90,7 @@ export class PatternPath implements IPatternPath {
         } else {
             index = 0;
         }
+
         this._segments = this._splitSegments(point, segmentIndex)[index];
         // Update data fields
         this._points = this._computePoints();
@@ -103,6 +103,7 @@ export class PatternPath implements IPatternPath {
         if (splitSegments.length !== 2) {
             throw new Error("Split did not return correct number of segments");
         }
+        
         const segmentsBeforePoint = [];
         for (let i = 0; i < segmentIndex; i++) {
             segmentsBeforePoint.push(this._segments[i]);

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -148,6 +148,27 @@ export class PatternPath implements IPatternPath {
         return new PatternPath(this._type, reversedSegments);
     };
 
+    equals = (other: PatternPath): boolean => {
+        if (this === other) {
+            return true;
+        }
+        
+        if (this._type !== other._type) {
+            return false;
+        }
+
+        if (this._segments.length !== other._segments.length) {
+            return false;
+        }
+
+        for (let i = 0; i < this._segments.length; i++) {
+            if (!this._segments[i].equals(other._segments[i])) {
+                return false;
+            }
+        }
+        return true;        
+    };
+
     private _getOffsetSegments = (allowanceSize: number): Segment[] => {
         // Find the array of segments that form the offset of the current
         // path. 

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -2,6 +2,8 @@ import { Point } from '../Geometry/Point';
 import { PatternPathType } from '../Enums';
 import { Segment } from 'canvas/Geometry/Segment';
 import { Vector } from 'canvas/Geometry/Vector';
+import { LineSegment } from 'canvas/Geometry/LineSegment';
+import { App } from 'canvas/AppController';
 
 export class PatternPath implements IPatternPath {
     protected _type: PatternPathType;
@@ -76,6 +78,68 @@ export class PatternPath implements IPatternPath {
         
         return [new PatternPath(this._type, segmentsOfFirstPath), 
                 new PatternPath(this._type, segmentsOfSecondPath)];
+    };
+
+    getAllowance = (): PatternPath => {
+        // Get the path that is offset from this one
+        const offsetSegments = this._getOffsetSegments();
+
+        // Add a line segment at the beginning of the offset path,
+        // following the tangent of the offset at that point  
+        const first = offsetSegments[0];      
+        const p1 = first.getStart();
+        const p2 = Point.translate(p1, first.getTangent(0).normalize().multiplyByScalar(-100));
+        
+        // Add a line segment at the end of the offset path,
+        // following the tangent of the offset at that point
+        const last = offsetSegments[offsetSegments.length - 1];
+        const q1 = last.getEnd();
+        const q2 = Point.translate(q1, last.getTangent(1).normalize().multiplyByScalar(100));
+        
+        let result: Segment[] = [new LineSegment(p2, p1)];
+        result = result.concat(offsetSegments);
+        result.push(new LineSegment(q1, q2));
+        return new PatternPath(this._type, result);
+    };
+
+    translate = (displacement: Vector): void => {
+        this._segments.forEach(segment => {
+            segment.translate(displacement);
+        });
+        this._path2D = this._computePath2D();
+    };
+
+    clone = (): PatternPath => {
+        const segments: Segment[] = [];
+        for (let i = 0; i < this._segments.length; i++) {
+            segments.push(this._segments[i].clone());
+        }
+        return new PatternPath(this._type, segments);
+    };
+
+    reversedClone = (): PatternPath => {
+        const reversedSegments: Segment[] = [];
+        for (let i = this._segments.length - 1; i >= 0; i--) {
+            reversedSegments.push(this._segments[i].reversedClone());
+        }
+        return new PatternPath(this._type, reversedSegments);
+    }
+
+    private _getOffsetSegments = (): Segment[] => {
+        // Set the allowance size according to the type of pattern path
+        const allowanceSize = App.document.getAllowanceSize(this._type);
+        if (allowanceSize === undefined) {
+            throw new Error("an allowance size was not defined for this type of path");
+        }
+
+        // Find the array of segments that form the offset of the current
+        // path. 
+        let offsetSegments: Segment[] = [];
+        this._segments.forEach(segment => {
+            offsetSegments = offsetSegments.concat(segment.getOffsetSegments(allowanceSize));
+        });
+
+        return offsetSegments;
     };
 
     private _computePoints = (): Point[] => {

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -134,7 +134,7 @@ export class PatternPath implements IPatternPath {
         let result: Segment[] = [new LineSegment(p2, p1)];
         result = result.concat(offsetSegments);
         result.push(new LineSegment(q1, q2));
-        return new PatternPath(this._type, result);
+        return new PatternPath(PatternPathType.Allowance, result);
     };
 
     translate = (displacement: Vector): void => {

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -87,8 +87,6 @@ export class PatternPath implements IPatternPath {
             throw new Error("Split did not return correct number of segments");
         }
 
-        console.log("trimming segment " + segmentIndex + " after intersection");
-
         const newSegments = [];
         for (let i = 0; i < segmentIndex; i++) {
             newSegments.push(this._segments[i]);
@@ -106,9 +104,6 @@ export class PatternPath implements IPatternPath {
         if (splitSegments.length !== 2) {
             throw new Error("Split did not return correct number of segments");
         }
-
-        console.log("trimming segment " + segmentIndex + " before intersection");
-
         const newSegments = [splitSegments[1]];
         for (let i = segmentIndex + 1; i < this._segments.length; i++) {
             newSegments.push(this._segments[i]);
@@ -122,7 +117,7 @@ export class PatternPath implements IPatternPath {
     getAllowance = (): PatternPath => {
         // Get the path that is offset from this one
         const offsetSegments = this._getOffsetSegments();
-        const lengthOfLineProlongations = 100;
+        const lengthOfLineProlongations = 200;
 
         // Add a line segment at the beginning of the offset path,
         // following the tangent of the offset at that point  

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -2,7 +2,6 @@ import { Point } from '../Geometry/Point';
 import { PatternPathType } from '../Enums';
 import { Segment } from 'canvas/Geometry/Segment';
 import { Vector } from 'canvas/Geometry/Vector';
-import { LineSegment } from 'canvas/Geometry/LineSegment';
 
 export class PatternPath implements IPatternPath {
     protected _type: PatternPathType;
@@ -102,29 +101,6 @@ export class PatternPath implements IPatternPath {
         this._path2D = this._computePath2D();
     };
 
-    getAllowance = (allowanceSize: number): PatternPath => {
-        // Get the path that is offset from this one
-        const offsetSegments = this._getOffsetSegments(allowanceSize);
-        const lengthOfLineSegmentProlongations = 200;
-
-        // Add a line segment at the beginning of the offset path,
-        // following the tangent of the offset at that point  
-        const firstSegment = offsetSegments[0];      
-        const p1 = firstSegment.getStart();
-        const p2 = Point.translate(p1, firstSegment.getTangent(0).normalize().multiplyByScalar(-1 * lengthOfLineSegmentProlongations));
-        
-        // Add a line segment at the end of the offset path,
-        // following the tangent of the offset at that point
-        const lastSegment = offsetSegments[offsetSegments.length - 1];
-        const q1 = lastSegment.getEnd();
-        const q2 = Point.translate(q1, lastSegment.getTangent(1).normalize().multiplyByScalar(lengthOfLineSegmentProlongations));
-        
-        let result: Segment[] = [new LineSegment(p2, p1)];
-        result = result.concat(offsetSegments);
-        result.push(new LineSegment(q1, q2));
-        return new PatternPath(PatternPathType.Allowance, result);
-    };
-
     translate = (displacement: Vector): void => {
         this._segments.forEach(segment => {
             segment.translate(displacement);
@@ -167,17 +143,6 @@ export class PatternPath implements IPatternPath {
             }
         }
         return true;        
-    };
-
-    private _getOffsetSegments = (allowanceSize: number): Segment[] => {
-        // Find the array of segments that form the offset of the current
-        // path. 
-        let offsetSegments: Segment[] = [];
-        this._segments.forEach(segment => {
-            offsetSegments = offsetSegments.concat(segment.getOffsetSegments(allowanceSize));
-        });
-
-        return offsetSegments;
     };
 
     private _computePoints = (): Point[] => {

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -80,6 +80,45 @@ export class PatternPath implements IPatternPath {
                 new PatternPath(this._type, segmentsOfSecondPath)];
     };
 
+    trimAfterPoint = (intersection: Point, segmentIndex: number): void => {
+        const segmentToSplit = this._segments[segmentIndex];
+        const splitSegments = segmentToSplit.split(intersection);
+        if (splitSegments.length !== 2) {
+            throw new Error("Split did not return correct number of segments");
+        }
+
+        console.log("trimming segment " + segmentIndex + " after intersection");
+
+        const newSegments = [];
+        for (let i = 0; i < segmentIndex; i++) {
+            newSegments.push(this._segments[i]);
+        }
+        newSegments.push(splitSegments[0]);
+
+        this._segments = newSegments;
+        this._points = this._computePoints();
+        this._path2D = this._computePath2D();
+    };
+
+    trimBeforePoint = (intersection: Point, segmentIndex: number): void => {
+        const segmentToSplit = this._segments[segmentIndex];
+        const splitSegments = segmentToSplit.split(intersection);
+        if (splitSegments.length !== 2) {
+            throw new Error("Split did not return correct number of segments");
+        }
+
+        console.log("trimming segment " + segmentIndex + " before intersection");
+
+        const newSegments = [splitSegments[1]];
+        for (let i = segmentIndex + 1; i < this._segments.length; i++) {
+            newSegments.push(this._segments[i]);
+        }
+        
+        this._segments = newSegments;
+        this._points = this._computePoints();
+        this._path2D = this._computePath2D();
+    };
+
     getAllowance = (): PatternPath => {
         // Get the path that is offset from this one
         const offsetSegments = this._getOffsetSegments();

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -147,7 +147,7 @@ export class PatternPath implements IPatternPath {
             reversedSegments.push(this._segments[i].reversedClone());
         }
         return new PatternPath(this._type, reversedSegments);
-    }
+    };
 
     private _getOffsetSegments = (): Segment[] => {
         // Set the allowance size according to the type of pattern path

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -114,22 +114,28 @@ export class PatternPath implements IPatternPath {
         this._path2D = this._computePath2D();
     };
 
+    addSegment = (newSegment: Segment): void => {
+        this._segments.push(newSegment);
+        this._points = this._computePoints();
+        this._path2D = this._computePath2D();
+    };
+
     getAllowance = (): PatternPath => {
         // Get the path that is offset from this one
         const offsetSegments = this._getOffsetSegments();
-        const lengthOfLineProlongations = 200;
+        const lengthOfLineSegmentProlongations = 200;
 
         // Add a line segment at the beginning of the offset path,
         // following the tangent of the offset at that point  
         const firstSegment = offsetSegments[0];      
         const p1 = firstSegment.getStart();
-        const p2 = Point.translate(p1, firstSegment.getTangent(0).normalize().multiplyByScalar(-1 * lengthOfLineProlongations));
+        const p2 = Point.translate(p1, firstSegment.getTangent(0).normalize().multiplyByScalar(-1 * lengthOfLineSegmentProlongations));
         
         // Add a line segment at the end of the offset path,
         // following the tangent of the offset at that point
         const lastSegment = offsetSegments[offsetSegments.length - 1];
         const q1 = lastSegment.getEnd();
-        const q2 = Point.translate(q1, lastSegment.getTangent(1).normalize().multiplyByScalar(lengthOfLineProlongations));
+        const q2 = Point.translate(q1, lastSegment.getTangent(1).normalize().multiplyByScalar(lengthOfLineSegmentProlongations));
         
         let result: Segment[] = [new LineSegment(p2, p1)];
         result = result.concat(offsetSegments);

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -75,29 +75,24 @@ export class PatternPath implements IPatternPath {
     };
 
     /**
-     * Shortens the current path by removing the part that is after the inputted point.
+     * Shortens the current path by removing the part that is before or after the inputted point. 
+     * If trimBeforePoint is true, will remove the part of the path that is 
+     * before the point. Otherwise it will remove the part of the path that is after the point.
      * 
      * Precondition: the input point is on the path
      * 
      * @param point the point on the path where we split the path
      * @param segmentIndex the index of the path's segment that contains the point
      */
-    trimAfterPoint = (point: Point, segmentIndex: number): void => {
-        this._segments = this._splitSegments(point, segmentIndex)[0];
-        this._points = this._computePoints();
-        this._path2D = this._computePath2D();
-    };
-
-    /**
-     * Shortens the current path by removing the part that is before the inputted point.
-     * 
-     * Precondition: the input point is on the path
-     * 
-     * @param point the point on the path where we split the path
-     * @param segmentIndex the index of the path's segment that contains the point
-     */
-    trimBeforePoint = (point: Point, segmentIndex: number): void => {
-        this._segments = this._splitSegments(point, segmentIndex)[1];
+    trimAtPoint = (point: Point, segmentIndex: number, trimBeforePoint: boolean): void => {
+        let index;
+        if (trimBeforePoint) {
+            index = 1;
+        } else {
+            index = 0;
+        }
+        this._segments = this._splitSegments(point, segmentIndex)[index];
+        // Update data fields
         this._points = this._computePoints();
         this._path2D = this._computePath2D();
     };

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -3,7 +3,6 @@ import { PatternPathType } from '../Enums';
 import { Segment } from 'canvas/Geometry/Segment';
 import { Vector } from 'canvas/Geometry/Vector';
 import { LineSegment } from 'canvas/Geometry/LineSegment';
-import { App } from 'canvas/AppController';
 
 export class PatternPath implements IPatternPath {
     protected _type: PatternPathType;
@@ -103,9 +102,9 @@ export class PatternPath implements IPatternPath {
         this._path2D = this._computePath2D();
     };
 
-    getAllowance = (): PatternPath => {
+    getAllowance = (allowanceSize: number): PatternPath => {
         // Get the path that is offset from this one
-        const offsetSegments = this._getOffsetSegments();
+        const offsetSegments = this._getOffsetSegments(allowanceSize);
         const lengthOfLineSegmentProlongations = 200;
 
         // Add a line segment at the beginning of the offset path,
@@ -149,13 +148,7 @@ export class PatternPath implements IPatternPath {
         return new PatternPath(this._type, reversedSegments);
     };
 
-    private _getOffsetSegments = (): Segment[] => {
-        // Set the allowance size according to the type of pattern path
-        const allowanceSize = App.document.getAllowanceSize(this._type);
-        if (allowanceSize === undefined) {
-            throw new Error("an allowance size was not defined for this type of path");
-        }
-
+    private _getOffsetSegments = (allowanceSize: number): Segment[] => {
         // Find the array of segments that form the offset of the current
         // path. 
         let offsetSegments: Segment[] = [];

--- a/src/canvas/PatternPaths/PatternPath.tsx
+++ b/src/canvas/PatternPaths/PatternPath.tsx
@@ -58,60 +58,68 @@ export class PatternPath implements IPatternPath {
         return this._segments;
     };
 
-    splitAtPoint = (intersection: Point, segmentIndex: number): PatternPath[] => {
-        const segmentToSplit = this._segments[segmentIndex];
-        const splitSegments = segmentToSplit.split(intersection);
-        if (splitSegments.length !== 2) {
-            throw new Error("Split did not return correct number of segments");
-        }
-
-        const segmentsOfFirstPath = [];
-        for (let i = 0; i < segmentIndex; i++) {
-            segmentsOfFirstPath.push(this._segments[i]);
-        }
-        segmentsOfFirstPath.push(splitSegments[0]);
-
-        const segmentsOfSecondPath = [splitSegments[1]];
-        for (let i = segmentIndex + 1; i < this._segments.length; i++) {
-            segmentsOfSecondPath.push(this._segments[i]);
-        }
+    /**
+     * Returns an array of 2 new PatternPaths, one of the path from start to 
+     * the inputted point, the second from the inputted point to the end.
+     * 
+     * Precondition: the input point is on the path
+     * 
+     * @param point the point on the path where we split the path
+     * @param segmentIndex the index of the path's segment that contains the point
+     */
+    splitAtPoint = (point: Point, segmentIndex: number): PatternPath[] => {
+        const splitSegments = this._splitSegments(point, segmentIndex);
+        return [new PatternPath(this._type, splitSegments[0]),
+                new PatternPath(this._type, splitSegments[1])];    
         
-        return [new PatternPath(this._type, segmentsOfFirstPath), 
-                new PatternPath(this._type, segmentsOfSecondPath)];
     };
 
-    trimAfterPoint = (intersection: Point, segmentIndex: number): void => {
-        const segmentToSplit = this._segments[segmentIndex];
-        const splitSegments = segmentToSplit.split(intersection);
-        if (splitSegments.length !== 2) {
-            throw new Error("Split did not return correct number of segments");
-        }
-
-        const newSegments = [];
-        for (let i = 0; i < segmentIndex; i++) {
-            newSegments.push(this._segments[i]);
-        }
-        newSegments.push(splitSegments[0]);
-
-        this._segments = newSegments;
+    /**
+     * Shortens the current path by removing the part that is after the inputted point.
+     * 
+     * Precondition: the input point is on the path
+     * 
+     * @param point the point on the path where we split the path
+     * @param segmentIndex the index of the path's segment that contains the point
+     */
+    trimAfterPoint = (point: Point, segmentIndex: number): void => {
+        this._segments = this._splitSegments(point, segmentIndex)[0];
         this._points = this._computePoints();
         this._path2D = this._computePath2D();
     };
 
-    trimBeforePoint = (intersection: Point, segmentIndex: number): void => {
+    /**
+     * Shortens the current path by removing the part that is before the inputted point.
+     * 
+     * Precondition: the input point is on the path
+     * 
+     * @param point the point on the path where we split the path
+     * @param segmentIndex the index of the path's segment that contains the point
+     */
+    trimBeforePoint = (point: Point, segmentIndex: number): void => {
+        this._segments = this._splitSegments(point, segmentIndex)[1];
+        this._points = this._computePoints();
+        this._path2D = this._computePath2D();
+    };
+
+    private _splitSegments = (point: Point, segmentIndex: number): Segment[][] => {
         const segmentToSplit = this._segments[segmentIndex];
-        const splitSegments = segmentToSplit.split(intersection);
+        const splitSegments = segmentToSplit.split(point);
         if (splitSegments.length !== 2) {
             throw new Error("Split did not return correct number of segments");
         }
-        const newSegments = [splitSegments[1]];
+        const segmentsBeforePoint = [];
+        for (let i = 0; i < segmentIndex; i++) {
+            segmentsBeforePoint.push(this._segments[i]);
+        }
+        segmentsBeforePoint.push(splitSegments[0]);
+
+        const segmentsAfterPoint = [splitSegments[1]];
         for (let i = segmentIndex + 1; i < this._segments.length; i++) {
-            newSegments.push(this._segments[i]);
+            segmentsAfterPoint.push(this._segments[i]);
         }
         
-        this._segments = newSegments;
-        this._points = this._computePoints();
-        this._path2D = this._computePath2D();
+        return [segmentsBeforePoint, segmentsAfterPoint];
     };
 
     addSegment = (newSegment: Segment): void => {

--- a/src/canvas/PatternPaths/PatternPathColor.tsx
+++ b/src/canvas/PatternPaths/PatternPathColor.tsx
@@ -1,6 +1,7 @@
 import { PatternPathType } from '../Enums';
 
 const PatternPathColor: Map<PatternPathType | string, string> = new Map();
+PatternPathColor.set(PatternPathType.Allowance, '#000000');
 PatternPathColor.set(PatternPathType.Edge, '#F2E74B');
 PatternPathColor.set(PatternPathType.Fold, '#84BFA4');
 PatternPathColor.set(PatternPathType.Seam, '#248EA6');

--- a/src/canvas/PatternPiece.tsx
+++ b/src/canvas/PatternPiece.tsx
@@ -55,8 +55,8 @@ export class PatternPiece {
         const numAllowances = allowances.length;
         for (let i = 0; i < numAllowances; i++) {
             const intersections = this._findIntersectionBetweenPaths(allowances[i], allowances[(i + 1) % numAllowances]);
-            allowances[i].trimBeforePoint(intersections[0].point, intersections[0].indexOfSegmentCrossed);
-            allowances[(i + 1) % numAllowances].trimAfterPoint(intersections[1].point, intersections[1].indexOfSegmentCrossed);
+            allowances[i].trimAfterPoint(intersections[0].point, intersections[0].indexOfSegmentCrossed);
+            allowances[(i + 1) % numAllowances].trimBeforePoint(intersections[1].point, intersections[1].indexOfSegmentCrossed);
         }
         this._allowancePaths = allowances;
     };
@@ -64,9 +64,6 @@ export class PatternPiece {
     private _findIntersectionBetweenPaths = (path1: PatternPath, path2: PatternPath): IIntersection[] => {
         // find first encountered intersection of paths, exploring path1 in reverse direction and path2 in regular direction
         
-        console.log("path1 segments: " + path1.getSegments());
-        console.log("path2 segments: " + path2.getSegments());
-
         const reversedPath1 = path1.reversedClone();
         const reversedPath1Segments = reversedPath1.getSegments();
         const numSegmentsIn1 = reversedPath1Segments.length;
@@ -77,7 +74,7 @@ export class PatternPiece {
                 const intersectionOnPath2 = PathIntersection.findIntersectionOfLineSegmentAndPath(lineSeg, path2);
                 if (intersectionOnPath2) {
                     return [
-                        // Intersection on path 1
+                        // Intersection on path 1 (not reversed)
                         {
                             point: intersectionOnPath2.point,
                             pathCrossed: path1,

--- a/src/canvas/PatternPiece.tsx
+++ b/src/canvas/PatternPiece.tsx
@@ -97,7 +97,9 @@ export class PatternPiece {
      * @param path2 The second PatternPath
      */
     private _findIntersectionBetweenPaths = (path1: PatternPath, path2: PatternPath): IIntersection[] | null => {
-        // find first encountered intersection of paths, exploring path1 in reverse direction and path2 in regular direction
+        // In order to trim the allowances correctly, we need to find the intersection 
+        // between path1 and path2 that is closest to the end of path1 and to the start of path 2.
+        // In order to do that, we explore path1 in reverse direction and path2 in regular direction
         
         const reversedPath1 = path1.reversedClone();
         const reversedPath1Segments = reversedPath1.getSegments();

--- a/src/canvas/PatternPiece.tsx
+++ b/src/canvas/PatternPiece.tsx
@@ -18,7 +18,7 @@ export class PatternPiece {
      */
     constructor(paths: PatternPath[]) {
         this._paths = paths;
-        this._allowancePaths = [];
+        this._allowancePaths = this._computeAllowancePaths();
     }
     
     /**
@@ -44,7 +44,7 @@ export class PatternPiece {
         });
     };
 
-    computeAllowancePaths = (): void => {
+    private _computeAllowancePaths = (): PatternPath[] => {
         // First, compute the allowance paths.
         // These are prolonged paths that run parallel to the edges.
         const allowances = this._paths.map(path => path.getAllowance());
@@ -65,7 +65,7 @@ export class PatternPiece {
             }
             
         }
-        this._allowancePaths = allowances;
+        return allowances;
     };
 
     private _findIntersectionBetweenPaths = (path1: PatternPath, path2: PatternPath): IIntersection[] | null=> {

--- a/src/canvas/PatternPiece.tsx
+++ b/src/canvas/PatternPiece.tsx
@@ -1,0 +1,98 @@
+import { PatternPath } from './PatternPaths/PatternPath';
+import { Vector } from 'canvas/Geometry/Vector';
+
+export class PatternPiece {
+    private _paths: PatternPath[];
+    private _allowances: PatternPath[];
+
+    /**
+     * Constructs a PatternPiece object from the provided 
+     * PatternPath array.
+     * 
+     * @param paths ordered paths going counterclockwise 
+     *              around the piece. The end of a path should
+     *              be the exact same point as the start of the
+     *              following path
+     */
+    constructor(paths: PatternPath[]) {
+        this._paths = paths;
+        this._allowances = [];
+    }
+    
+    /**
+     * Returns all of the PatternPath edges and PatternPath 
+     * allowances of the pattern piece
+     */
+    getAllPaths = (): PatternPath[] => {
+        return [...this._paths, ...this._allowances];
+    };
+
+    /**
+     * Translates the patternPiece in the plane following the
+     * provided displacement vector.
+     * 
+     * @param displacement 
+     */
+    translate = (displacement: Vector): void => {
+        this._paths.forEach(path => {
+            path.translate(displacement);
+        });
+        this._allowances.forEach(path => {
+            path.translate(displacement);
+        });
+    };
+
+    addAllowances = (): void => {
+        // First, compute the allowance paths.
+        // These are prolonged paths that run parallel to the edges.
+        const allowances = this._paths.map(path => path.getAllowance());
+
+        // Then, edge by edge, find the intersection between the alloance of 
+        // an edge and the allowance of the next and shorten the allowances
+        // accordingly
+        const numAllowances = allowances.length;
+        for (let i = 0; i < numAllowances; i++) {
+            this._trimPastIntersection(allowances[i], allowances[(i + 1) % numAllowances]);
+        }
+        this._allowances = allowances;
+    };
+
+    private _trimPastIntersection = (allow1: PatternPath, allow2: PatternPath): void => {
+        // const intersections = this._findIntersectionBetweenPaths(allow1, allow2);
+
+        // if (!intersections) {
+        //     console.log("Could not find intersection between 2 consecutive allowance PatternPahts");
+        // } else {
+        //     console.log("intersections: " + intersections[0].point + ", " + intersections[1].point);
+        //     //move this out of else once debugging is complete
+        //     allow1 = PathIntersection.splitAtIntersection(intersections[0].point, intersections[0].pathCrossed, intersections[0].indexOfSegmentCrossed)[0];
+        //     allow2 = PathIntersection.splitAtIntersection(intersections[1].point, intersections[1].pathCrossed, intersections[1].indexOfSegmentCrossed)[1];
+        // }
+    };
+
+    private _findIntersectionBetweenPaths = (path1: PatternPath, path2: PatternPath): IIntersection[] | null => {
+        // find first encountered intersection of paths, exploring path1 in reverse direction and path2 in regular direction
+        
+        // const reversedPath1 = path1.reversedClone();
+        // const reversedPath1Points = reversedPath1.getPoints();
+        // const numSegmentsIn1 = reversedPath1Points.length;
+        // for (let segmentIndex = 0; segmentIndex < numSegmentsIn1; segmentIndex++) {
+        //     const segmentPoints = reversedPath1Points[segmentIndex];
+        //     for (let j = 1; j < segmentPoints.length; j++) {
+        //         const lineSeg = new LineSegment(segmentPoints[j - 1], segmentPoints[j]);
+        //         const intersectionOn2 = PathIntersection.findIntersectionOfLineSegmentAndPath(lineSeg, path2);
+        //         if (intersectionOn2) {
+        //             return [
+        //                 {
+        //                     point: intersectionOn2.point,
+        //                     pathCrossed: path1,
+        //                     indexOfSegmentCrossed: numSegmentsIn1 - segmentIndex
+        //                 }, 
+        //                 intersectionOn2
+        //             ];
+        //         }
+        //     }
+        // }      
+        return null;
+    };
+}

--- a/src/canvas/PatternPiece.tsx
+++ b/src/canvas/PatternPiece.tsx
@@ -57,7 +57,7 @@ export class PatternPiece {
             allowances.push(path.getAllowance(allowanceSize));
         });
 
-        // Then, edge by edge, find the intersection between the alloance of 
+        // Then, edge by edge, find the intersection between the allowance of 
         // an edge and the allowance of the next and shorten the allowances
         // accordingly
         const numAllowances = allowances.length;

--- a/src/canvas/PatternPiece.tsx
+++ b/src/canvas/PatternPiece.tsx
@@ -45,6 +45,14 @@ export class PatternPiece {
         });
     };
 
+    /**
+     * Computes and returns an array of PatternPaths that represent the allowance lines
+     * of all the pattern lines of this pattern piece, spacing them outwards of the pattern 
+     * piece at a distance specified by the inputted map and the PatternPaths' types.
+     * 
+     * @param allowanceSizes The map indicating the width of the allowance that each type 
+     *                       of PatternPath should have.
+     */
     private _computeAllowancePaths = (allowanceSizes: Map<PatternPathType, number>): PatternPath[] => {
         // First, compute the allowance paths.
         // These are prolonged paths that run parallel to the edges.
@@ -76,7 +84,19 @@ export class PatternPiece {
         return allowances;
     };
 
-    private _findIntersectionBetweenPaths = (path1: PatternPath, path2: PatternPath): IIntersection[] | null=> {
+    /**
+     * If the two inputted paths have no intersection, returns null. Otherwise, returns
+     * an array containing two intersections, both containing the same intersections point,
+     * each describing which path is being intersected and on which segment the
+     * intersection happens.
+     * 
+     * If path1 and path2 have more than 1 intersection, the method will only find and return the
+     * intersection that is closest to the end of path1 and the start of path 2.
+     * 
+     * @param path1 The first PatternPath
+     * @param path2 The second PatternPath
+     */
+    private _findIntersectionBetweenPaths = (path1: PatternPath, path2: PatternPath): IIntersection[] | null => {
         // find first encountered intersection of paths, exploring path1 in reverse direction and path2 in regular direction
         
         const reversedPath1 = path1.reversedClone();

--- a/src/canvas/PatternPiece.tsx
+++ b/src/canvas/PatternPiece.tsx
@@ -2,6 +2,7 @@ import { PatternPath } from './PatternPaths/PatternPath';
 import { Vector } from 'canvas/Geometry/Vector';
 import { LineSegment } from './Geometry/LineSegment';
 import { PathIntersection } from './PathIntersection';
+import { PatternPathType } from './Enums';
 
 export class PatternPiece {
     private _paths: PatternPath[];
@@ -16,9 +17,9 @@ export class PatternPiece {
      *              be the exact same point as the start of the
      *              following path
      */
-    constructor(paths: PatternPath[]) {
+    constructor(paths: PatternPath[], allowanceSizes: Map<PatternPathType, number>) {
         this._paths = paths;
-        this._allowancePaths = this._computeAllowancePaths();
+        this._allowancePaths = this._computeAllowancePaths(allowanceSizes);
     }
     
     /**
@@ -44,10 +45,17 @@ export class PatternPiece {
         });
     };
 
-    private _computeAllowancePaths = (): PatternPath[] => {
+    private _computeAllowancePaths = (allowanceSizes: Map<PatternPathType, number>): PatternPath[] => {
         // First, compute the allowance paths.
         // These are prolonged paths that run parallel to the edges.
-        const allowances = this._paths.map(path => path.getAllowance());
+        const allowances: PatternPath[] = [];
+        this._paths.forEach((path) => {
+            const allowanceSize = allowanceSizes.get(path.getType());
+            if (allowanceSize === undefined) {
+                throw new Error("Could not determine the allowance size for the path type " + path.getType());
+            }
+            allowances.push(path.getAllowance(allowanceSize));
+        });
 
         // Then, edge by edge, find the intersection between the alloance of 
         // an edge and the allowance of the next and shorten the allowances

--- a/src/canvas/PatternPiece.tsx
+++ b/src/canvas/PatternPiece.tsx
@@ -54,27 +54,19 @@ export class PatternPiece {
         // accordingly
         const numAllowances = allowances.length;
         for (let i = 0; i < numAllowances; i++) {
-            this._trimPastIntersection(allowances[i], allowances[(i + 1) % numAllowances]);
+            const intersections = this._findIntersectionBetweenPaths(allowances[i], allowances[(i + 1) % numAllowances]);
+            allowances[i].trimBeforePoint(intersections[0].point, intersections[0].indexOfSegmentCrossed);
+            allowances[(i + 1) % numAllowances].trimAfterPoint(intersections[1].point, intersections[1].indexOfSegmentCrossed);
         }
         this._allowancePaths = allowances;
     };
 
-    private _trimPastIntersection = (allow1: PatternPath, allow2: PatternPath): void => {
-        const intersections = this._findIntersectionBetweenPaths(allow1, allow2);
-
-        // if (!intersections) {
-        //     console.log("Could not find intersection between 2 consecutive allowance PatternPahts");
-        // } else {
-        //     console.log("intersections: " + intersections[0].point + ", " + intersections[1].point);
-        //     //move this out of else once debugging is complete
-        //     allow1 = PathIntersection.splitAtIntersection(intersections[0].point, intersections[0].pathCrossed, intersections[0].indexOfSegmentCrossed)[0];
-        //     allow2 = PathIntersection.splitAtIntersection(intersections[1].point, intersections[1].pathCrossed, intersections[1].indexOfSegmentCrossed)[1];
-        // }
-    };
-
-    private _findIntersectionBetweenPaths = (path1: PatternPath, path2: PatternPath): IIntersection[] | null => {
+    private _findIntersectionBetweenPaths = (path1: PatternPath, path2: PatternPath): IIntersection[] => {
         // find first encountered intersection of paths, exploring path1 in reverse direction and path2 in regular direction
         
+        console.log("path1 segments: " + path1.getSegments());
+        console.log("path2 segments: " + path2.getSegments());
+
         const reversedPath1 = path1.reversedClone();
         const reversedPath1Segments = reversedPath1.getSegments();
         const numSegmentsIn1 = reversedPath1Segments.length;
@@ -82,20 +74,20 @@ export class PatternPiece {
             const segmentPoints = reversedPath1Segments[segmentIndex].getPoints();
             for (let j = 1; j < segmentPoints.length; j++) {
                 const lineSeg = new LineSegment(segmentPoints[j - 1], segmentPoints[j]);
-                const intersectionOn2 = PathIntersection.findIntersectionOfLineSegmentAndPath(lineSeg, path2);
-                if (intersectionOn2) {
+                const intersectionOnPath2 = PathIntersection.findIntersectionOfLineSegmentAndPath(lineSeg, path2);
+                if (intersectionOnPath2) {
                     return [
-                        // Intersection on 1
+                        // Intersection on path 1
                         {
-                            point: intersectionOn2.point,
+                            point: intersectionOnPath2.point,
                             pathCrossed: path1,
                             indexOfSegmentCrossed: numSegmentsIn1 - segmentIndex - 1
                         }, 
-                        intersectionOn2
+                        intersectionOnPath2
                     ];
                 }
             }
         }      
-        return null;
+        throw new Error("Could not find any intersection between 2 consecutive allowances");
     };
 }

--- a/src/canvas/PatternPiece.tsx
+++ b/src/canvas/PatternPiece.tsx
@@ -56,8 +56,8 @@ export class PatternPiece {
         for (let i = 0; i < numAllowances; i++) {
             const intersections = this._findIntersectionBetweenPaths(allowances[i], allowances[(i + 1) % numAllowances]);
             if (intersections) {
-                allowances[i].trimAfterPoint(intersections[0].point, intersections[0].indexOfSegmentCrossed);
-                allowances[(i + 1) % numAllowances].trimBeforePoint(intersections[1].point, intersections[1].indexOfSegmentCrossed);
+                allowances[i].trimAtPoint(intersections[0].point, intersections[0].indexOfSegmentCrossed, false);
+                allowances[(i + 1) % numAllowances].trimAtPoint(intersections[1].point, intersections[1].indexOfSegmentCrossed, true);
             } else {
                 // If no intersection was found, join the two allowance paths by adding a line segment at the end of the
                 // first allowance

--- a/src/canvas/PatternPiece.tsx
+++ b/src/canvas/PatternPiece.tsx
@@ -3,6 +3,7 @@ import { Vector } from 'canvas/Geometry/Vector';
 import { LineSegment } from './Geometry/LineSegment';
 import { PathIntersection } from './PathIntersection';
 import { PatternPathType } from './Enums';
+import { AllowanceFinder } from './PatternPaths/AllowanceFinder';
 
 export class PatternPiece {
     private _paths: PatternPath[];
@@ -62,7 +63,7 @@ export class PatternPiece {
             if (allowanceSize === undefined) {
                 throw new Error("Could not determine the allowance size for the path type " + path.getType());
             }
-            allowances.push(path.getAllowance(allowanceSize));
+            allowances.push(AllowanceFinder.FindAllowance(path, allowanceSize));
         });
 
         // Then, edge by edge, find the intersection between the allowance of 

--- a/src/canvas/Renderer.tsx
+++ b/src/canvas/Renderer.tsx
@@ -167,13 +167,6 @@ export class Renderer implements IRenderer {
         this._canvas.onmouseout = null;
     };
 
-    finalReviewInit = (): void => {
-        this._pathSelection.clear();
-
-        this._canvas.onmousedown = null;
-        this._canvas.onmousemove = null;
-    };
-
     /**
      * Checks if the point intersects another path. If it doesn't, it returns the point 
      * itself. If it does and the intersection is close to an endpoint of the path, we 

--- a/src/canvas/Renderer.tsx
+++ b/src/canvas/Renderer.tsx
@@ -136,7 +136,6 @@ export class Renderer implements IRenderer {
             const pathsRemovedThisTracingSession = this._document.getPatternPathsTrash();
             this._document.removePatternPath();
             this._undoPathReplacementsInTracingSession(pathsRemovedThisTracingSession);
-            console.log("paths", this._document.getPatternPaths());
         }) as EventListener);
 
         return this._canvas;

--- a/src/canvas/Renderer.tsx
+++ b/src/canvas/Renderer.tsx
@@ -264,8 +264,6 @@ export class Renderer implements IRenderer {
                     newPatternPath = new PatternPath(this._pathType, [CurveFitter.Fit(points)]);
             }
             this._document.addPatternPath(newPatternPath);
-
-            console.log("paths", this._document.getPatternPaths());
             this._canvas.dispatchEvent(new Event('endTracing'));     
         }
 

--- a/src/pages/Trace/AddMeasurement/AddMeasurement.tsx
+++ b/src/pages/Trace/AddMeasurement/AddMeasurement.tsx
@@ -40,7 +40,7 @@ export const AddMeasurement: React.FC<AddMeasurementProps> = ({ setUploadedFileD
                 warningModal.current = <></>;
                 App.document.setSizeRatio(parseFloat(inputMeasurement), selectedPath);
                 App.document.setAllowanceSizes(); // Setting to default values
-                App.document.computePatternPieces();
+                App.document.findPatternPieces();
             }
         }
     };

--- a/src/pages/Trace/AddMeasurement/AddMeasurement.tsx
+++ b/src/pages/Trace/AddMeasurement/AddMeasurement.tsx
@@ -40,7 +40,7 @@ export const AddMeasurement: React.FC<AddMeasurementProps> = ({ setUploadedFileD
                 warningModal.current = <></>;
                 App.document.setSizeRatio(parseFloat(inputMeasurement), selectedPath);
                 App.document.setAllowanceSizes(); // Setting to default values
-                App.document.prepPatternPieces();
+                App.document.computePatternPieces();
             }
         }
     };

--- a/src/pages/Trace/AddMeasurement/AddMeasurement.tsx
+++ b/src/pages/Trace/AddMeasurement/AddMeasurement.tsx
@@ -39,7 +39,8 @@ export const AddMeasurement: React.FC<AddMeasurementProps> = ({ setUploadedFileD
             } else {
                 warningModal.current = <></>;
                 App.document.setSizeRatio(parseFloat(inputMeasurement), selectedPath);
-                App.document.findPatternPieces();
+                App.document.setAllowanceSizes(); // Setting to default values
+                App.document.prepPatternPieces();
             }
         }
     };

--- a/src/pages/Trace/FinalReview/FinalReview.tsx
+++ b/src/pages/Trace/FinalReview/FinalReview.tsx
@@ -3,8 +3,6 @@ import { App } from "canvas/AppController";
 
 export const FinalReview: React.FC = () => {
     useEffect(() => {
-        //App.renderer.finalReviewInit();
-
         // for inspection of paths on final review
         App.renderer.measurementInit();
     }, []);

--- a/src/pages/Trace/FinalReview/FinalReview.tsx
+++ b/src/pages/Trace/FinalReview/FinalReview.tsx
@@ -3,7 +3,10 @@ import { App } from "canvas/AppController";
 
 export const FinalReview: React.FC = () => {
     useEffect(() => {
-        App.renderer.finalReviewInit();
+        //App.renderer.finalReviewInit();
+
+        // for inspection of paths on final review
+        App.renderer.measurementInit();
     }, []);
     
     return (<>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -89,11 +89,8 @@ type IPatternPathTrash = {
 };
 
 type IEdge = {
-    origin: Point;
-    destination: Point;
-    tangentAtOrigin: Vector;
-    tangentAtDestination: Vector;
-    index: number; // the index of the segment
-    isReversed: boolean; // true if the edge is in the same direction
-                         // as the segment, false otherwise
+    path: PatternPath;
+    startVertex: Point;
+    endVertex: Point;
+    id: number;
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -87,3 +87,13 @@ type IPatternPathTrash = {
     path: PatternPath; 
     replacement: PatternPath[];
 };
+
+type IEdge = {
+    origin: Point;
+    destination: Point;
+    tangentAtOrigin: Vector;
+    tangentAtDestination: Vector;
+    index: number; // the index of the segment
+    isReversed: boolean; // true if the edge is in the same direction
+                         // as the segment, false otherwise
+};

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -29,7 +29,7 @@ type IDocument = {
     arePatternPiecesEnclosed: () => boolean;
     isEmpty: () => boolean;
     setSizeRatio: (inputMeasurementInches: number, selectecPath: PatternPath) => void;
-    findPatternPieces: () => void;
+    prepPatternPieces: () => void;
 };
 
 type ITracingPath = {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -29,7 +29,7 @@ type IDocument = {
     arePatternPiecesEnclosed: () => boolean;
     isEmpty: () => boolean;
     setSizeRatio: (inputMeasurementInches: number, selectecPath: PatternPath) => void;
-    prepPatternPieces: () => void;
+    computePatternPieces: () => void;
 };
 
 type ITracingPath = {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -29,7 +29,7 @@ type IDocument = {
     arePatternPiecesEnclosed: () => boolean;
     isEmpty: () => boolean;
     setSizeRatio: (inputMeasurementInches: number, selectecPath: PatternPath) => void;
-    computePatternPieces: () => void;
+    findPatternPieces: () => void;
 };
 
 type ITracingPath = {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -75,7 +75,6 @@ type IVector = {
 type IRenderer = {
     init: () => HTMLCanvasElement;
     measurementInit: () => void;
-    finalReviewInit: () => void;
 };
 
 type IIntersection = {


### PR DESCRIPTION
Add the allowances to our Pattern Pieces. This includes the following changes:
- FaceFinder now returns more data on the edges that form the faces: it also specifies if a path needs to be reversed in order for the paths to all go around the face in the positive rotation direction
- Update of the FaceFinder tests to support new feature
- Creation of a new class PatternPiece that holds the PatternPaths (all going around the face, in order, in the positive rotation direction) of one single pattern piece and its allowance paths, and has functionality to compute these allowances.
- Implementation of getOffsetSegments on all Segment classes
- Implementation of .clone() and .reversedClone() on all Segment classes as well as on PatternPaths
- Implementation of .translate on all Segment classes, on PatternPaths and on PatternPieces
- Finished the implementation of .getTangent() for Curve subclasses
- Document now has data field, getter and setter for allowance sizes
- Allowance sizes are set to default values by AddMeasurement page on click of the input button
