### PR TITLE
Snap along path on mouse up

### DIFF
--- a/src/canvas/Renderer.tsx
+++ b/src/canvas/Renderer.tsx
@@ -61,12 +61,14 @@ export class Renderer implements IRenderer {
                 case(ToolType.Freeline):
                     this._currPath = new FreeLinePath();
                     break;
+                default:
+                    throw new Error("Could not identify the tool type");
             }
 
             const position = new Point(e.offsetX, e.offsetY);
             this._currPath.addPoint(position);
             // Try to snap to other endpoints
-            const snapStartPoint = this._currPath?.snapStartPoint(this._document.getPatternPaths());
+            const snapStartPoint = this._currPath.snapStartPoint(this._document.getPatternPaths());
             // If we were unable to snap to other endpoints, we will try to snap along other paths.
             if (!snapStartPoint) {
                 const snappedPosition = this._checkPointIntersectionAndSplit(position, this._document.getPatternPaths());
@@ -238,7 +240,7 @@ export class Renderer implements IRenderer {
         if (this._currPath) {
             this._currPath.addPoint(position);
             // Try to snap to other endpoints
-            const snapEndPoint = this._currPath?.snapEndPoint(this._document.getPatternPaths());
+            const snapEndPoint = this._currPath.snapEndPoint(this._document.getPatternPaths());
             // If we were unable to snap to other endpoints, we will try to snap along other paths.
             if (!snapEndPoint) {
                 const snappedPosition = this._checkPointIntersectionAndSplit(position, this._document.getPatternPaths());

--- a/src/canvas/Renderer.tsx
+++ b/src/canvas/Renderer.tsx
@@ -69,7 +69,7 @@ export class Renderer implements IRenderer {
             const snapStartPoint = this._currPath?.snapStartPoint(this._document.getPatternPaths());
             // If we were unable to snap to other endpoints, we will try to snap along other paths.
             if (!snapStartPoint) {
-                const snappedPosition = this._checkPathStartIntersectionAndSplit(position, this._document.getPatternPaths());
+                const snappedPosition = this._checkPointIntersectionAndSplit(position, this._document.getPatternPaths());
                 this._currPath.snapStartPointTo(snappedPosition);
             }
         };
@@ -183,13 +183,13 @@ export class Renderer implements IRenderer {
      * intersected path is bisected at the intersection point and the original path is replaced with
      * the two new paths in the document. 
      */
-    private _checkPathStartIntersectionAndSplit = (startPoint: Point, paths: PatternPath[]): Point => {
-        const intersection = PathIntersection.findPointIntersectAlongPatternPaths(startPoint, paths);
+    private _checkPointIntersectionAndSplit = (point: Point, paths: PatternPath[]): Point => {
+        const intersection = PathIntersection.findPointIntersectAlongPatternPaths(point, paths);
         if (intersection) {
             this._splitPathAtIntersection(intersection);
             return intersection.point;
         }
-        return startPoint;
+        return point;
     };
 
     private _draw = (): void => {

--- a/src/canvas/Renderer.tsx
+++ b/src/canvas/Renderer.tsx
@@ -237,8 +237,14 @@ export class Renderer implements IRenderer {
     private _endTracing = (position: Point): void => {
         if (this._currPath) {
             this._currPath.addPoint(position);
-            this._currPath.snapEndPoint(this._document.getPatternPaths());
-            
+            // Try to snap to other endpoints
+            const snapEndPoint = this._currPath?.snapEndPoint(this._document.getPatternPaths());
+            // If we were unable to snap to other endpoints, we will try to snap along other paths.
+            if (!snapEndPoint) {
+                const snappedPosition = this._checkPointIntersectionAndSplit(position, this._document.getPatternPaths());
+                this._currPath.snapEndPointTo(snappedPosition);
+            }
+
             let newPatternPath;
             const points = this._currPath.getPoints();
             switch (this._toolType) {

--- a/src/canvas/TracingPaths/TracingPath.tsx
+++ b/src/canvas/TracingPaths/TracingPath.tsx
@@ -103,6 +103,15 @@ export abstract class TracingPath implements ITracingPath {
         return updatedEndPoint;
     };
 
+    /**
+     * Sets the end point of the tracing path to the given point.
+     * 
+     * @param point A point where the tracing path should end.
+     */
+    snapEndPointTo = (point: Point): void => {
+        this._points[this._points.length - 1] = point;    
+    };
+
     private _snapEndPoints = (patternPaths: PatternPath[], index: number): boolean => {
         const point = this._points[index];
         // Radius to check within to see if we should snap to point.


### PR DESCRIPTION
- Reuse the snapping code we use on mouse down on _endTracing for the end point.
- Add a throw if the currPath was not initialized and remove the ? checks on currPath