### PR TITLE
Single clicks bug fix

### DIFF
--- a/src/canvas/Renderer.tsx
+++ b/src/canvas/Renderer.tsx
@@ -325,9 +325,4 @@ export class Renderer implements IRenderer {
             this._document.addPatternPath(pathRemoved.path);
         });
     };
-
-    // private _update = (): void => {
-    //     console.log("update");
-    // }
-
 }

--- a/src/canvas/Renderer.tsx
+++ b/src/canvas/Renderer.tsx
@@ -236,31 +236,48 @@ export class Renderer implements IRenderer {
     private _endTracing = (position: Point, snapEndPoint: boolean): void => {
         if (this._currPath) {
             this._currPath.addPoint(position);
-            if (snapEndPoint) {
-                // Try to snap to other endpoints
-                const snapEndPoint = this._currPath.snapEndPoint(this._document.getPatternPaths());
-                // If we were unable to snap to other endpoints, we will try to snap along other paths.
-                if (!snapEndPoint) {
-                    const snappedPosition = this._checkPointIntersectionAndSplit(position, this._document.getPatternPaths());
-                    this._currPath.snapEndPointTo(snappedPosition);
+
+            // Require a minimum of 2 points for lines and 3 points for curves
+            if ((this._toolType === ToolType.StraightLine && this._currPath.getPoints().length >= 2) ||
+                (this._toolType === ToolType.Freeline && this._currPath.getPoints().length >= 3)) {
+                if (snapEndPoint) {
+                    // Try to snap to other endpoints
+                    const snappedToEndPoint = this._currPath.snapEndPoint(this._document.getPatternPaths());
+                    
+                    // If we snapped the end to the same point as the start, undo 
+                    // any path splitting we might have done on mouse down and 
+                    // reset currPath but keep the same ToolType
+                    if (snappedToEndPoint && this._currPath.isFirstPointEqualToLastPoint()) {
+                        const pathsRemovedThisTracingSession = this._document.getPatternPathsTrash();
+                        this._undoPathReplacementsInTracingSession(pathsRemovedThisTracingSession);
+                        this._currPath = null;
+                        return;
+                    }
+
+                    // If we were unable to snap to other endpoints, we will try to snap along other paths.
+                    if (!snappedToEndPoint) {
+                        const snappedPosition = this._checkPointIntersectionAndSplit(position, this._document.getPatternPaths());
+                        this._currPath.snapEndPointTo(snappedPosition);
+                    }
                 }
-            }
 
-            let newPatternPath;
-            const points = this._currPath.getPoints();
-            switch (this._toolType) {
-                case ToolType.StraightLine:
-                    newPatternPath = new PatternPath(this._pathType, [new LineSegment(points[0], points[1])]);
-                    break;
-                case ToolType.Freeline:
-                    newPatternPath = new PatternPath(this._pathType, [CurveFitter.Fit(points)]);
-            }
-            this._document.addPatternPath(newPatternPath);
-            this._canvas.dispatchEvent(new Event('endTracing'));     
+                let newPatternPath;
+                const points = this._currPath.getPoints();
+                switch (this._toolType) {
+                    case ToolType.StraightLine:
+                        newPatternPath = new PatternPath(this._pathType, [new LineSegment(points[0], points[1])]);
+                        break;
+                    case ToolType.Freeline:
+                        newPatternPath = new PatternPath(this._pathType, [CurveFitter.Fit(points)]);
+                }
+                this._document.addPatternPath(newPatternPath);
+                this._canvas.dispatchEvent(new Event('endTracing'));
+                this._resetTracing();
+            } else { // If we don't have enough points, reset currPath but keep the same ToolType
+                this._currPath = null;
+            }            
         }
-
-        this._resetTracing();
-    };
+    }
 
     /**
      * Splits the path from the intersection in 2 paths at the point

--- a/src/canvas/Renderer.tsx
+++ b/src/canvas/Renderer.tsx
@@ -279,7 +279,7 @@ export class Renderer implements IRenderer {
 
     /**
      *  Undoes any path splitting we might have done while drawing currPath and 
-     *  reset currPath
+     *  resets currPath
      */
     private _discardCurrPath = () => {
         const pathsRemovedThisTracingSession = this._document.getPatternPathsTrash();

--- a/src/canvas/TracingPaths/TracingPath.tsx
+++ b/src/canvas/TracingPaths/TracingPath.tsx
@@ -18,8 +18,8 @@ export abstract class TracingPath implements ITracingPath {
         return this._points;
     };
 
-    isFirstPointEqualToLastPoint = (): boolean => {
-        return this._points[0].equals(this._points[this._points.length - 1]);
+    isFirstPointCloseToLastPoint = (radius: number): boolean => {
+        return this._points[0].isWithinRadius(this._points[this._points.length - 1], radius);
     };
 
     getPath2D = (): Path2D => {
@@ -124,12 +124,12 @@ export abstract class TracingPath implements ITracingPath {
         for (let i = 0; i < patternPaths.length; i++) {
             const patternPath = patternPaths[i];
 
-            if(point.isWithinRadius(patternPath.getStart(), radius)) {
+            if (point.isWithinRadius(patternPath.getStart(), radius)) {
                 this._points[index] = patternPath.getStart();
                 return true;
             }
 
-            if(point.isWithinRadius(patternPath.getEnd(), radius)) {
+            if (point.isWithinRadius(patternPath.getEnd(), radius)) {
                 this._points[index] = patternPath.getEnd();
                 return true;
             }

--- a/src/canvas/TracingPaths/TracingPath.tsx
+++ b/src/canvas/TracingPaths/TracingPath.tsx
@@ -18,6 +18,10 @@ export abstract class TracingPath implements ITracingPath {
         return this._points;
     };
 
+    isFirstPointEqualToLastPoint = (): boolean => {
+        return this._points[0].equals(this._points[this._points.length - 1]);
+    };
+
     getPath2D = (): Path2D => {
         // If the Path2D is already valid, return it.
         if (this._isPath2DValid) {
@@ -116,23 +120,22 @@ export abstract class TracingPath implements ITracingPath {
         const point = this._points[index];
         // Radius to check within to see if we should snap to point.
         const radius = 10;
-        let updatedPoint = false;
 
         for (let i = 0; i < patternPaths.length; i++) {
             const patternPath = patternPaths[i];
 
-            if(!updatedPoint && point.isWithinRadius(patternPath.getStart(), radius)) {
+            if(point.isWithinRadius(patternPath.getStart(), radius)) {
                 this._points[index] = patternPath.getStart();
-                updatedPoint = true;
+                return true;
             }
 
-            if(!updatedPoint && point.isWithinRadius(patternPath.getEnd(), radius)) {
+            if(point.isWithinRadius(patternPath.getEnd(), radius)) {
                 this._points[index] = patternPath.getEnd();
-                updatedPoint = true;
+                return true;
             }
         }
 
-        return updatedPoint;
+        return false;
     };
 
     protected abstract _updatePath2D(): void;


### PR DESCRIPTION
Bugs description:
- When doing a single click on the canvas, the renderer tries to create a path from one point and throws.
- When doing a single click along a pattern path, the path splitting that was done on mouse down has to be undone.

Bug fix: 
- create a _discardCurrPath helper method in Renderer that cleans up path splitting and resets currPath
- call discardCurrPath if we don't have a sufficient number of points
- call discardCurrPath if the the first and last point of currPath are too close together

also, _snapEndPoints in TracingPath was optimized slightly by returning as soon as snapping is done