### PR TITLE
ArcCurve optimisation and fix

### DIFF
--- a/src/canvas/Geometry/ArcCurve.tsx
+++ b/src/canvas/Geometry/ArcCurve.tsx
@@ -68,6 +68,8 @@ export class ArcCurve extends Curve {
     };
 
     getTangent = (t: number): Vector => {
+        // The tangent vector is found by calculating the derivative of the parametric equation of the circle arc:
+        // C'(t) = ( -(endAngle - startAngle)*r*\sin(startAngle + (endAngle - startAngle)t), (endAngle - startAngle)*r*\cos(startAngle + (endAngle - startAngle)t))
         const x = -1 * (this.endAngle - this.startAngle) * this.radius * Math.sin(this.lerp(this.startAngle, this.endAngle, t));
         const y = (this.endAngle - this.startAngle) * this.radius * Math.cos(this.lerp(this.startAngle, this.endAngle, t));
         return new Vector(x, y);

--- a/src/canvas/Geometry/ArcCurve.tsx
+++ b/src/canvas/Geometry/ArcCurve.tsx
@@ -84,8 +84,8 @@ export class ArcCurve extends Curve {
     split = (point: Point): ArcCurve[] => {
         const curves:  ArcCurve[] = [];
         const originToSplitPoint = Vector.vectorBetweenPoints(this.center, point);
-        const tangetToArcAtPoint = Vector.findPerpVector(originToSplitPoint);
-        const pointOnTangentToArcAtPoint = Point.translate(point, tangetToArcAtPoint);
+        const tangentToArcAtPoint = Vector.findPerpVector(originToSplitPoint);
+        const pointOnTangentToArcAtPoint = Point.translate(point, tangentToArcAtPoint);
         const lineOnTangentToArcAtPoint = new LineSegment(point, pointOnTangentToArcAtPoint);
         const lineFromStartToOldControlPoint = new LineSegment(this.start, this.control);
 

--- a/src/canvas/Geometry/ArcCurve.tsx
+++ b/src/canvas/Geometry/ArcCurve.tsx
@@ -62,7 +62,10 @@ export class ArcCurve extends Curve {
         result.start = Point.translate(this.start, displacementOfStart);
         result.end = Point.translate(this.end, displacementOfEnd);
         result.radius = result.start.distanceTo(result.center);
-        result.control = Point.translate(Point.translate(this.control, displacementOfStart), displacementOfEnd); 
+
+        const lengthOfDisplacementOfControl = distance / Math.cos(Math.abs(this.endAngle - this.startAngle) / 2);
+        const displacementOfControl = Vector.vectorBetweenPoints(this.center, this.control).normalize().multiplyByScalar(lengthOfDisplacementOfControl);
+        result.control = Point.translate(this.control, displacementOfControl);
         // result's center, startAngle and endAngle don't need to be updated.
         return [result];
     };

--- a/src/canvas/Geometry/Curve.tsx
+++ b/src/canvas/Geometry/Curve.tsx
@@ -79,6 +79,17 @@ export abstract class Curve extends Segment {
     protected lerp = (start: number, end: number, t: number): number => {
         return start + t * (end - start);
     };
-
+    
+    /**
+     * Returns the point on the parametric curve at the specified
+     * parameter t value. t must be between 0 and 1 inclusively.
+     * If t = 0, will return the starting point, and if t = 1, will
+     * return the end point. 
+     * 
+     * Overrides the abstract method in the parent class.
+     * 
+     * @param t number between 0 and 1 indicating the position on the 
+     *          curve, where 0 is the start and 1 the end
+     */
     protected abstract _computePoint(t: number): Point;
 }


### PR DESCRIPTION
In ArcCurve:
- fixed a bug in getOffsetSegment: the control point was not computed correctly.
- fixed a typo in split()
- added a comment in getTangent to document the math
- rewrote computeCenter() in a simpler way by reusing the line intersection code

In Curve: 
- documented _computePoint()